### PR TITLE
Fix SDK version and user agent in ApiClient header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@
 - Changed example for work with webhook in [README.md](README.md) file and directory `/examples/webhook/`
 - Changed example for work with local application in [README.md](README.md) file and directory
   `/examples/local-application/`
+- Changed bitrix24-php-sdk version in headers in class `Bitrix24\SDK\Core\ApiClient`,
+  see [wrong API-client and sdk version in headers](https://github.com/bitrix24/b24phpsdk/issues/13).
 
 <!--
 ### Deprecated

--- a/src/Core/ApiClient.php
+++ b/src/Core/ApiClient.php
@@ -37,9 +37,9 @@ class ApiClient implements ApiClientInterface
     /**
      * @const string
      */
-    protected const SDK_VERSION = '2.0.0';
+    protected const SDK_VERSION = '1.1.0';
 
-    protected const SDK_USER_AGENT = 'bitrix24-php-sdk';
+    protected const SDK_USER_AGENT = 'b24-php-sdk';
 
     /**
      * ApiClient constructor.


### PR DESCRIPTION
Corrected the SDK version from '2.0.0' to '1.1.0' and updated the user agent string to 'b24-php-sdk' in `Bitrix24\SDK\Core\ApiClient` class. Also updated the changelog to reflect these changes.

| Q             | A                                                                                                                         |
|---------------|---------------------------------------------------------------------------------------------------------------------------|
| Bug fix?      | yes                                                                                                                    |
| New feature?  | no                                                                            |
| Deprecations? | no                                                                            |
| Issues        | Fix #13  |
| License       | **MIT**                                                                                                                       |

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally:
 - Always add tests and ensure they pass.
 - For new features, provide some code snippets to help understand usage.
-->