### PR TITLE
Make core property public in AbstractServiceBuilder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 ### Security
 -->
 
-## 1.1.0 – 2024.09.
+## 1.1.0 – 2024.09.12
 
 ### Added
 
@@ -27,6 +27,8 @@
   `/examples/local-application/`
 - Changed bitrix24-php-sdk version in headers in class `Bitrix24\SDK\Core\ApiClient`,
   see [wrong API-client and sdk version in headers](https://github.com/bitrix24/b24phpsdk/issues/13).
+- Changed scope for property `core` in `Bitrix24\SDK\Services\AbstractServiceBuilder` - for better DX,
+  see [Make core public in service builder](https://github.com/bitrix24/b24phpsdk/issues/26).
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -125,6 +125,9 @@ $b24Service = ServiceBuilderFactory::createServiceBuilderFromWebhook('INSERT_HER
 
 // call some method
 var_dump($b24Service->getMainScope()->main()->getApplicationInfo()->applicationInfo());
+// call core for method in not implemented service
+var_dump($b24Service->core->call('user.current'));
+
 ```
 5. Call php file in shell
 

--- a/examples/webhook/example.php
+++ b/examples/webhook/example.php
@@ -16,7 +16,9 @@ use Bitrix24\SDK\Services\ServiceBuilderFactory;
 require_once 'vendor/autoload.php';
 
 // init bitrix24-php-sdk service from webhook
-$b24Service = ServiceBuilderFactory::createServiceBuilderFromWebhook('INSERT_HERE_YOUR_WEBHOOK_URL');
+$b24Service = ServiceBuilderFactory::createServiceBuilderFromWebhook('https://bitrix24-php-sdk-playground.bitrix24.ru/rest/1/b6g6r1zr85pzzpw5/');
 
 // call some method
 var_dump($b24Service->getMainScope()->main()->getApplicationInfo()->applicationInfo());
+// call core
+var_dump($b24Service->core->call('user.current'));

--- a/src/Services/AbstractServiceBuilder.php
+++ b/src/Services/AbstractServiceBuilder.php
@@ -13,42 +13,29 @@ declare(strict_types=1);
 
 namespace Bitrix24\SDK\Services;
 
-
 use Bitrix24\SDK\Core\Contracts\BatchOperationsInterface;
 use Bitrix24\SDK\Core\Contracts\BulkItemsReaderInterface;
 use Bitrix24\SDK\Core\Contracts\CoreInterface;
 use Psr\Log\LoggerInterface;
 
-/**
- * Class AbstractServiceBuilder
- *
- * @package Bitrix24\SDK\Services
- */
 abstract class AbstractServiceBuilder
 {
-    protected CoreInterface $core;
-    protected BatchOperationsInterface $batch;
-    protected BulkItemsReaderInterface $bulkItemsReader;
-    protected LoggerInterface $log;
     protected array $serviceCache;
 
     /**
      * AbstractServiceBuilder constructor.
      *
-     * @param CoreInterface                                         $core
-     * @param BatchOperationsInterface                              $batch
-     * @param \Bitrix24\SDK\Core\Contracts\BulkItemsReaderInterface $bulkItemsReader
-     * @param LoggerInterface                                       $log
+     * @param CoreInterface $core
+     * @param BatchOperationsInterface $batch
+     * @param BulkItemsReaderInterface $bulkItemsReader
+     * @param LoggerInterface $log
      */
     public function __construct(
-        CoreInterface $core,
-        BatchOperationsInterface $batch,
-        BulkItemsReaderInterface $bulkItemsReader,
-        LoggerInterface $log
-    ) {
-        $this->core = $core;
-        $this->batch = $batch;
-        $this->bulkItemsReader = $bulkItemsReader;
-        $this->log = $log;
+        public CoreInterface               $core,
+        protected BatchOperationsInterface $batch,
+        protected BulkItemsReaderInterface $bulkItemsReader,
+        protected LoggerInterface          $log
+    )
+    {
     }
 }


### PR DESCRIPTION
Changed the core property scope in AbstractServiceBuilder to public for improved developer experience. Updated the CHANGELOG with the new release date and documented the change in property scope. Also, revised the webhook example to demonstrate using the public core property.

| Q             | A                                                                                                                         |
|---------------|---------------------------------------------------------------------------------------------------------------------------|
| Bug fix?      | no                                                                                                                    |
| New feature?  | yes                                                                          |
| Deprecations? | yes                                                                           |
| Issues        | Fix #26  |
| License       | **MIT**                                                                                                                       |

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally:
 - Always add tests and ensure they pass.
 - For new features, provide some code snippets to help understand usage.
-->