### PR TITLE
Update changelog date and standardize issue template titles

### DIFF
--- a/.github/ISSUE_TEMPLATE/1_bug_report_sdk.yaml
+++ b/.github/ISSUE_TEMPLATE/1_bug_report_sdk.yaml
@@ -1,7 +1,7 @@
 name: 🐛 SDK bug report
 description: SDK bug report template
 labels: bug in SDK
-
+title: "[Bug in SDK]: "
 body:
   - type: input
     id: affected-versions

--- a/.github/ISSUE_TEMPLATE/2_feature_request_sdk.yaml
+++ b/.github/ISSUE_TEMPLATE/2_feature_request_sdk.yaml
@@ -1,7 +1,7 @@
 name: 🚀 SDK Feature Request
 description: Ideas for new features and improvements in SDK
 labels: enhancement in SDK
-
+title: "[Feature in SDK]: "
 body:
   - type: textarea
     id: description

--- a/.github/ISSUE_TEMPLATE/3_bug_report_rest_api.yaml
+++ b/.github/ISSUE_TEMPLATE/3_bug_report_rest_api.yaml
@@ -1,7 +1,7 @@
 name: 🐛 REST-API bug report
 description: REST-API bug report template
 labels: bug in REST-API
-
+title: "[Bug in REST-API]: "
 body:
   - type: input
     id: api-method

--- a/.github/ISSUE_TEMPLATE/4_feature_request_rest_api.yaml
+++ b/.github/ISSUE_TEMPLATE/4_feature_request_rest_api.yaml
@@ -1,7 +1,7 @@
 name: 🚀 REST-API Feature Request
 description: Ideas for new features and improvements in REST-API
 labels: enhancement in REST-API
-
+title: "[Feature in REST-API]: "
 body:
   - type: textarea
     id: description

--- a/.github/ISSUE_TEMPLATE/5_ship_release.yaml
+++ b/.github/ISSUE_TEMPLATE/5_ship_release.yaml
@@ -1,0 +1,25 @@
+name: 🚢 Ship new SDK release
+description: Tasks for ship new SDK release
+labels: enhancement in SDK
+title: "[Ship new SDK release]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        - [ ] write release notes documentation in the changelog.MD
+        - [ ] update version in all code examples in main README.md
+        - [ ] update the version in headers in the file `/src/Core/ApiClient.php`
+        - [ ] update version in examples folder
+        - [ ] checkout each example with release branch and test it
+        - [ ] rebuild the list of the supported methods in SDK documentation
+        - [ ] local pass phpstan linter
+        - [ ] local pass rector linter
+        - [ ] local pass PHPUnit tests
+        - [ ] pass all integration tests by scope
+  - type: input
+    id: new version
+    attributes:
+      label: new version
+      placeholder: x.y.z
+    validations:
+      required: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 ### Security
 -->
 
-## 1.1.0 – 2024.09.24
+## 1.1.0 – 2024.09.25
 
 ### Added
 
@@ -40,10 +40,10 @@
   with [wrong signature events](https://apidocs.bitrix24.com/api-reference/events/safe-event-handlers.html) with
   `application_token`.
 - Added checks for empty string in args for constructor `Bitrix24\SDK\Core\Credentials\ApplicationProfile`
-- Added checks for empty string in args for constructor `Bitrix24\SDK\Core\Credentials\ApplicationProfile`
 - Added class `Bitrix24\SDK\Application\Requests\Events\ApplicationLifeCycleEventsFabric`
-- Documentation: added section [Basic necessary knowledge](docs/EN/documentation.md) in [SDK documentation](https://github.com/bitrix24/b24phpsdk/issues/35)
-- Documentation: added section [Call unsupported methods in SDK](docs/EN/documentation.md) in [SDK documentation](https://github.com/bitrix24/b24phpsdk/issues/15)
+- Documentation: added section [Basic necessary knowledge](docs/EN/README.md) in [SDK documentation](https://github.com/bitrix24/b24phpsdk/issues/35)
+- Documentation: added section [Call unsupported methods](docs/EN/README.md) in [SDK documentation](https://github.com/bitrix24/b24phpsdk/issues/15)
+- Developer experience: add issue template [Ship new SDK release](https://github.com/bitrix24/b24phpsdk/issues/42)  
 
 ### Changed
 


### PR DESCRIPTION
Corrected the release date in CHANGELOG.md from 2024.09.24 to 2024.09.25. Standardized issue template titles by adding prefixes, and introduced a new template for shipping SDK releases.

| Q             | A                                                                                                                         |
|---------------|---------------------------------------------------------------------------------------------------------------------------|
| Bug fix?      | no                                                                                                                    |
| New feature?  | yes <!-- please update CHANGELOG.md file -->                                                                           |
| Deprecations? | no <!-- please update CHANGELOG.md file -->                                                                           |
| Issues        | Fix #42 <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead --> |
| License       | **MIT**                                                                                                                       |

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally:
 - Always add tests and ensure they pass.
 - For new features, provide some code snippets to help understand usage.
-->