### PR TITLE
Fix WorkflowDocumentId parsing and add unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ tools/logs
 tests/ApplicationBridge/auth.json
 examples/logs
 /var
+*.private.env.*
 *.log
 .env.local
 *.local

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # b24-php-sdk change log
 
+## 1.2.0 – 2024.11.?
+
+### Fixed
+
+- Fixed errors in `Bitrix24\SDK\Services\Workflows\Common\WorkflowDocumentId`,
+  see [parsing errors](https://github.com/bitrix24/b24phpsdk/issues/54).
+
 <!--
 ## Unreleased
 ### Added
@@ -31,10 +38,11 @@
       `applicationToken`.
     - `Local\Infrastructure\Filesystem\AppAuthFileStorage`: class for store LocalAppAuth in file
     - `Local\Repository\LocalAppAuthRepositoryInterface`: interface for LocalAppAuthRepository.
-- Developer experience: added example `/examples/local-app-with-token-storage` for demonstrate all options for work with SDK and created local
+- Developer experience: added example `/examples/local-app-with-token-storage` for demonstrate all options for work with
+  SDK and created local
   application skeleton.
-- Developer experience: added example `/examples/webhook-error-handling` for demonstrate exceptions handling. 
-- Developer experience: added example `/examples/local-app-placement` for demonstrate work with placements. 
+- Developer experience: added example `/examples/webhook-error-handling` for demonstrate exceptions handling.
+- Developer experience: added example `/examples/local-app-placement` for demonstrate work with placements.
 - Added `WrongClientException` for handle errors with wrong application client configuration.
 - Added `PaymentRequiredException` for handle errors with expired subscription.
 - Added `WrongConfigurationException` for handle errors with wrong application infrastructure configuration.
@@ -43,9 +51,11 @@
   `application_token`.
 - Added checks for empty string in args for constructor `Bitrix24\SDK\Core\Credentials\ApplicationProfile`
 - Added class `Bitrix24\SDK\Application\Requests\Events\ApplicationLifeCycleEventsFabric`
-- Documentation: added section [Basic necessary knowledge](docs/EN/README.md) in [SDK documentation](https://github.com/bitrix24/b24phpsdk/issues/35)
-- Documentation: added section [Call unsupported methods](docs/EN/README.md) in [SDK documentation](https://github.com/bitrix24/b24phpsdk/issues/15)
-- Developer experience: add issue template [Ship new SDK release](https://github.com/bitrix24/b24phpsdk/issues/42)  
+- Documentation: added section [Basic necessary knowledge](docs/EN/README.md)
+  in [SDK documentation](https://github.com/bitrix24/b24phpsdk/issues/35)
+- Documentation: added section [Call unsupported methods](docs/EN/README.md)
+  in [SDK documentation](https://github.com/bitrix24/b24phpsdk/issues/15)
+- Developer experience: add issue template [Ship new SDK release](https://github.com/bitrix24/b24phpsdk/issues/42)
 
 ### Changed
 

--- a/src/Services/AbstractServiceBuilder.php
+++ b/src/Services/AbstractServiceBuilder.php
@@ -20,6 +20,9 @@ use Psr\Log\LoggerInterface;
 
 abstract class AbstractServiceBuilder
 {
+    /**
+     * @var array<string, mixed>
+     */
     protected array $serviceCache;
 
     /**

--- a/src/Services/Workflows/Common/WorkflowDocumentId.php
+++ b/src/Services/Workflows/Common/WorkflowDocumentId.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Bitrix24\SDK\Services\Workflows\Common;
 
-readonly class WorkflowDocumentId
+final readonly class WorkflowDocumentId
 {
     public function __construct(
         public string $moduleId,
@@ -25,7 +25,11 @@ readonly class WorkflowDocumentId
 
     public function getId(): int
     {
-        return (int)substr($this->targetDocumentId, 0, strpos('_', $this->targetDocumentId));
+        if (is_numeric($this->targetDocumentId)) {
+            return (int)$this->targetDocumentId;
+        }
+
+        return (int)substr($this->targetDocumentId, strrpos($this->targetDocumentId, '_') + 1);
     }
 
     public static function initFromArray(array $data): WorkflowDocumentId

--- a/src/Services/Workflows/Robot/Request/IncomingRobotRequest.php
+++ b/src/Services/Workflows/Robot/Request/IncomingRobotRequest.php
@@ -49,7 +49,7 @@ class IncomingRobotRequest extends AbstractRequest
             WorkflowDocumentType::initFromArray($data['document_type']),
             $data['event_token'],
             $data['properties'],
-            $data['use_subscription'] === 'Y' ? true : false,
+            $data['use_subscription'] === 'Y',
             (int)$data['timeout_duration'],
             (int)$data['ts'],
             Auth::initFromArray($data['auth'])

--- a/tests/Unit/Services/Workflows/Common/WorkflowDocumentIdTest.php
+++ b/tests/Unit/Services/Workflows/Common/WorkflowDocumentIdTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Bitrix24\SDK\Tests\Unit\Services\Workflows\Common;
+
+use Bitrix24\SDK\Services\Workflows\Common\WorkflowDocumentId;
+use Generator;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(WorkflowDocumentId::class)]
+class WorkflowDocumentIdTest extends TestCase
+{
+    #[DataProvider('documentIdDataProvider')]
+    public function testInitFromArray(array $documentId, int $dealId): void
+    {
+        $documentId = WorkflowDocumentId::initFromArray($documentId);
+        $this->assertEquals(
+            $dealId,
+            $documentId->getId()
+        );
+    }
+
+    public static function documentIdDataProvider(): Generator
+    {
+        yield 'deal' => [
+            [
+                "crm",
+                "CCrmDocumentDeal",
+                "DEAL_165752"
+            ],
+            165752
+        ];
+        yield 'task' => [
+            [
+                "tasks",
+                "Bitrix\\Tasks\\Integration\\Bizproc\\Document\\Task",
+                "2"
+            ],
+            2
+        ];
+        yield 'smart process' => [
+            [
+                "crm",
+                "Bitrix\\Crm\\Integration\\BizProc\\Document\\Dynamic",
+                "DYNAMIC_1032_4"
+            ],
+            4
+        ];
+    }
+}


### PR DESCRIPTION
Updated `WorkflowDocumentId` class to fix document ID parsing logic, ensuring proper handling of numeric IDs and underscore-separated IDs. Added comprehensive unit tests to ensure reliability, and documented changes in the `CHANGELOG.md`.

| Q             | A                                                                                                                         |
|---------------|---------------------------------------------------------------------------------------------------------------------------|
| Bug fix?      | yes                                                                                                                    |
| New feature?  | no <!-- please update CHANGELOG.md file -->                                                                           |
| Deprecations? | no <!-- please update CHANGELOG.md file -->                                                                           |
| Issues        | Fix #54 ... <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead --> |
| License       | **MIT**                                                                                                                       |

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally:
 - Always add tests and ensure they pass.
 - For new features, provide some code snippets to help understand usage.
-->