### PR TITLE
Add nullable bitrix24UserId to findByMemberId method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@
 - Added method `Bitrix24AccountRepositoryInterface::findByApplicationToken` in contracts for
   support «[Delete Application](https://github.com/bitrix24/b24phpsdk/issues/62)» use case
 
+### Changed
+
+- Added nullable argument `bitrix24UserId` in method `Bitrix24AccountRepositoryInterface::findByMemberId` in contracts
+  for support use case «[RenewAuthToken](https://github.com/bitrix24/b24phpsdk/issues/63)»
+
 ### Fixed
 
 - Fixed errors in `Bitrix24\SDK\Services\Workflows\Common\WorkflowDocumentId`,

--- a/src/Application/Contracts/Bitrix24Accounts/Repository/Bitrix24AccountRepositoryInterface.php
+++ b/src/Application/Contracts/Bitrix24Accounts/Repository/Bitrix24AccountRepositoryInterface.php
@@ -49,9 +49,15 @@ interface Bitrix24AccountRepositoryInterface
     /**
      * Find bitrix24 accounts by member_id and filter by status and isAdmin flag
      * @param non-empty-string $memberId
+     * @param positive-int $bitrix24UserId
      * @return Bitrix24AccountInterface[]
      */
-    public function findByMemberId(string $memberId, ?Bitrix24AccountStatus $bitrix24AccountStatus = null, ?bool $isAdmin = null): array;
+    public function findByMemberId(
+        string                 $memberId,
+        ?Bitrix24AccountStatus $bitrix24AccountStatus = null,
+        ?int                   $bitrix24UserId = null,
+        ?bool                  $isAdmin = null
+    ): array;
 
     /**
      * Find bitrix24 accounts by applicationToken

--- a/tests/Application/Contracts/Bitrix24Accounts/Repository/Bitrix24AccountRepositoryInterfaceTest.php
+++ b/tests/Application/Contracts/Bitrix24Accounts/Repository/Bitrix24AccountRepositoryInterfaceTest.php
@@ -390,7 +390,7 @@ abstract class Bitrix24AccountRepositoryInterfaceTest extends TestCase
         $acc = $bitrix24AccountRepository->getById($uuid);
         $this->assertEquals($bitrix24Account, $acc);
 
-        $found = $bitrix24AccountRepository->findByMemberId($memberId, null, true);
+        $found = $bitrix24AccountRepository->findByMemberId($memberId, null, null, true);
         $this->assertEquals($acc, $found[0]);
     }
 
@@ -422,7 +422,39 @@ abstract class Bitrix24AccountRepositoryInterfaceTest extends TestCase
         $acc = $bitrix24AccountRepository->getById($uuid);
         $this->assertEquals($bitrix24Account, $acc);
 
-        $found = $bitrix24AccountRepository->findByMemberId($memberId, null, true);
+        $found = $bitrix24AccountRepository->findByMemberId($memberId, null, null, true);
+        $this->assertEquals([], $found);
+    }
+
+    /**
+     * @throws Bitrix24AccountNotFoundException
+     */
+    #[Test]
+    #[DataProvider('bitrix24AccountForInstallDataProvider')]
+    #[TestDox('test findByMemberId method with b24UserId - not found')]
+    final public function testFindByMemberIdWithB24UserIdNotFound(
+        Uuid                  $uuid,
+        int                   $bitrix24UserId,
+        bool                  $isBitrix24UserAdmin,
+        string                $memberId,
+        string                $domainUrl,
+        Bitrix24AccountStatus $bitrix24AccountStatus,
+        AuthToken             $authToken,
+        CarbonImmutable       $createdAt,
+        CarbonImmutable       $updatedAt,
+        int                   $applicationVersion,
+        Scope                 $applicationScope
+    ): void
+    {
+        $bitrix24Account = $this->createBitrix24AccountImplementation($uuid, $bitrix24UserId, $isBitrix24UserAdmin, $memberId, $domainUrl, $bitrix24AccountStatus, $authToken, $createdAt, $updatedAt, $applicationVersion, $applicationScope);
+        $bitrix24AccountRepository = $this->createBitrix24AccountRepositoryImplementation();
+
+        $bitrix24AccountRepository->save($bitrix24Account);
+
+        $acc = $bitrix24AccountRepository->getById($uuid);
+        $this->assertEquals($bitrix24Account, $acc);
+
+        $found = $bitrix24AccountRepository->findByMemberId($memberId, null, $bitrix24UserId + 1, $isBitrix24UserAdmin);
         $this->assertEquals([], $found);
     }
 
@@ -446,7 +478,7 @@ abstract class Bitrix24AccountRepositoryInterfaceTest extends TestCase
         Scope                 $applicationScope
     ): void
     {
-        $bitrix24Account = $this->createBitrix24AccountImplementation($uuid, $bitrix24UserId, false, $memberId, $domainUrl, $bitrix24AccountStatus, $authToken, $createdAt, $updatedAt, $applicationVersion, $applicationScope);
+        $bitrix24Account = $this->createBitrix24AccountImplementation($uuid, $bitrix24UserId, $isBitrix24UserAdmin, $memberId, $domainUrl, $bitrix24AccountStatus, $authToken, $createdAt, $updatedAt, $applicationVersion, $applicationScope);
         $bitrix24AccountRepository = $this->createBitrix24AccountRepositoryImplementation();
 
         $bitrix24AccountRepository->save($bitrix24Account);
@@ -454,7 +486,7 @@ abstract class Bitrix24AccountRepositoryInterfaceTest extends TestCase
         $acc = $bitrix24AccountRepository->getById($uuid);
         $this->assertEquals($bitrix24Account, $acc);
 
-        $found = $bitrix24AccountRepository->findByMemberId($memberId, Bitrix24AccountStatus::new, false);
+        $found = $bitrix24AccountRepository->findByMemberId($memberId, Bitrix24AccountStatus::new, $bitrix24UserId, $isBitrix24UserAdmin);
         $this->assertEquals($acc, $found[0]);
     }
 
@@ -704,6 +736,7 @@ abstract class Bitrix24AccountRepositoryInterfaceTest extends TestCase
             $found[0]->getId()
         );
     }
+
     #[Test]
     #[TestDox('test FindByApplicationToken method with empty string')]
     final public function testFindByApplicationTokenWithEmptyString(): void

--- a/tests/Unit/Application/Contracts/Bitrix24Accounts/Repository/InMemoryBitrix24AccountRepositoryImplementation.php
+++ b/tests/Unit/Application/Contracts/Bitrix24Accounts/Repository/InMemoryBitrix24AccountRepositoryImplementation.php
@@ -91,7 +91,11 @@ class InMemoryBitrix24AccountRepositoryImplementation implements Bitrix24Account
     /**
      * @throws InvalidArgumentException
      */
-    public function findByMemberId(string $memberId, ?Bitrix24AccountStatus $bitrix24AccountStatus = null, ?bool $isAdmin = null): array
+    public function findByMemberId(string                 $memberId,
+                                   ?Bitrix24AccountStatus $bitrix24AccountStatus = null,
+                                   ?int                   $bitrix24UserId = null,
+                                   ?bool                  $isAdmin = null
+    ): array
     {
         $this->logger->debug('b24AccountRepository.findByMemberId', [
             'memberId' => $memberId,
@@ -110,9 +114,10 @@ class InMemoryBitrix24AccountRepositoryImplementation implements Bitrix24Account
             }
 
             $isStatusMatch = (!$bitrix24AccountStatus instanceof Bitrix24AccountStatus || $bitrix24AccountStatus === $item->getStatus());
+            $b24UserMatch = ($bitrix24UserId === null || $bitrix24UserId === $item->getBitrix24UserId());
             $isAdminMatch = ($isAdmin === null || $isAdmin === $item->isBitrix24UserAdmin());
 
-            if ($isStatusMatch && $isAdminMatch) {
+            if ($isStatusMatch && $b24UserMatch && $isAdminMatch) {
                 $items[] = $item;
             }
 


### PR DESCRIPTION
Enhanced `findByMemberId` method to accept an optional `bitrix24UserId` argument for better filtering capabilities. Updated relevant tests and documentation to reflect this change.

| Q             | A                                                                                                                         |
|---------------|---------------------------------------------------------------------------------------------------------------------------|
| Bug fix?      | no                                                                                                                    |
| New feature?  | yes <!-- please update CHANGELOG.md file -->                                                                           |
| Deprecations? | no <!-- please update CHANGELOG.md file -->                                                                           |
| Issues        | Fix #63  <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead --> |
| License       | **MIT**                                                                                                                       |

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally:
 - Always add tests and ensure they pass.
 - For new features, provide some code snippets to help understand usage.
-->