### PR TITLE
Add nullable comments to account events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 - Added method `Bitrix24AccountRepositoryInterface::findByApplicationToken` in contracts for
   support «[Delete Application](https://github.com/bitrix24/b24phpsdk/issues/62)» use case
 - Added `Bitrix24\SDK\Application\Contracts\Bitrix24Accounts\Exceptions\MultipleBitrix24AccountsFoundException`
+- Added nullable comments in events `Bitrix24AccountBlockedEvent` and `Bitrix24AccountUnblockedEvent`,
+  see [add comment to events](https://github.com/bitrix24/b24phpsdk/issues/79).
 
 ### Changed
 

--- a/src/Application/Contracts/Bitrix24Accounts/Events/Bitrix24AccountBlockedEvent.php
+++ b/src/Application/Contracts/Bitrix24Accounts/Events/Bitrix24AccountBlockedEvent.php
@@ -20,8 +20,9 @@ use Symfony\Contracts\EventDispatcher\Event;
 class Bitrix24AccountBlockedEvent extends Event
 {
     public function __construct(
-        public readonly Uuid            $bitrix24AccountId,
-        public readonly CarbonImmutable $timestamp)
-    {
+        public readonly Uuid $bitrix24AccountId,
+        public readonly CarbonImmutable $timestamp,
+        public readonly ?string $comment = null
+    ) {
     }
 }

--- a/src/Application/Contracts/Bitrix24Accounts/Events/Bitrix24AccountUnblockedEvent.php
+++ b/src/Application/Contracts/Bitrix24Accounts/Events/Bitrix24AccountUnblockedEvent.php
@@ -20,8 +20,9 @@ use Symfony\Contracts\EventDispatcher\Event;
 class Bitrix24AccountUnblockedEvent extends Event
 {
     public function __construct(
-        public readonly Uuid            $bitrix24AccountId,
-        public readonly CarbonImmutable $timestamp)
-    {
+        public readonly Uuid $bitrix24AccountId,
+        public readonly CarbonImmutable $timestamp,
+        public readonly ?string $comment = null
+    ) {
     }
 }


### PR DESCRIPTION
Added an optional comment field to `Bitrix24AccountBlockedEvent` and `Bitrix24AccountUnblockedEvent`. This change allows including context or additional information when these events are triggered. Refer to the related issue for more details.

| Q             | A                                                                                                                         |
|---------------|---------------------------------------------------------------------------------------------------------------------------|
| Bug fix?      | no                                                                                                                    |
| New feature?  | yes <!-- please update CHANGELOG.md file -->                                                                           |
| Deprecations? | no <!-- please update CHANGELOG.md file -->                                                                           |
| Issues        | Fix #79  <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead --> |
| License       | **MIT**                                                                                                                       |

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally:
 - Always add tests and ensure they pass.
 - For new features, provide some code snippets to help understand usage.
-->