### PR TITLE
Add strict parameter order handling for specific API methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,8 @@
   `user.get`, [see details](https://github.com/bitrix24/b24phpsdk/issues/103)
 - Fixed errors in `Bitrix24\SDK\Core\Batch` for methods `entity.item.get` and
   `entity.item.update`, [see details](https://github.com/bitrix24/b24phpsdk/issues/53)
+- Fixed errors in `Bitrix24\SDK\Core\ApiClient` for methods with strict arguments
+  order, [see details](https://github.com/bitrix24/b24phpsdk/issues/101)
 
 ### Statistics
 

--- a/tests/Integration/Core/CoreStrictParamsOrderTest.php
+++ b/tests/Integration/Core/CoreStrictParamsOrderTest.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * This file is part of the bitrix24-php-sdk package.
+ *
+ * © Maksim Mesilov <mesilov.maxim@gmail.com>
+ *
+ * For the full copyright and license information, please view the MIT-LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Bitrix24\SDK\Tests\Integration\Core;
+
+use Bitrix24\SDK\Core\Contracts\CoreInterface;
+use Bitrix24\SDK\Tests\Integration\Fabric;
+use Fig\Http\Message\StatusCodeInterface;
+use PHPUnit\Framework\TestCase;
+
+
+class CoreStrictParamsOrderTest extends TestCase
+{
+    protected CoreInterface $core;
+
+    public function testCallMethodWithStrictParamsOrder(): void
+    {
+        $response = $this->core->call(
+            'task.commentitem.getlist',
+            [
+                2,
+                [
+                    "ID" => "desc"
+                ],
+                [
+                    "AUTHOR_ID" => 1
+                ]
+            ]
+        );
+        $this->assertEquals(StatusCodeInterface::STATUS_OK, $response->getHttpResponse()->getStatusCode());
+    }
+
+    public function setUp(): void
+    {
+        $this->core = Fabric::getCore(false, true);
+    }
+}


### PR DESCRIPTION
Introduced logic to handle strict parameter order required by certain Bitrix24 API methods, ensuring compatibility and correctness. Added integration test `CoreStrictParamsOrderTest` to validate this behavior and updated the SDK version to 1.3.0 to reflect the changes. Updated the CHANGELOG to document the fix.

| Q             | A                                                                                                                         |
|---------------|---------------------------------------------------------------------------------------------------------------------------|
| Bug fix?      | yes                                                                                                                    |
| New feature?  | no <!-- please update CHANGELOG.md file -->                                                                           |
| Deprecations? | no <!-- please update CHANGELOG.md file -->                                                                           |
| Issues        | Fix #101  <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead --> |
| License       | **MIT**                                                                                                                       |

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally:
 - Always add tests and ensure they pass.
 - For new features, provide some code snippets to help understand usage.
-->