### PR TITLE
Add method to validate auth token via vendor OAUTH server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## Unreleased 1.3.0 – 2025.02.09
 
 ### Added
-
+- Added method `Bitrix24\SDK\Services\Main\Service::guardValidateCurrentAuthToken` for validate current auth token with
+  api-call `app.info` on vendor OAUTH server.
 - Added support new scope `entity`
 - Added service `Services\Entity\Service\Item` with support methods,
   see [fix entity.item.* methods](https://github.com/bitrix24/b24phpsdk/issues/53):
@@ -78,13 +79,18 @@
 - Fixed errors in `Bitrix24\SDK\Core\ApiClient` for methods with strict arguments
   order, [see details](https://github.com/bitrix24/b24phpsdk/issues/101)
 
+### Security
+
+- Added method `Bitrix24\SDK\Services\Main\Service::guardValidateCurrentAuthToken` for validate current auth token with
+  api-call `app.info` on vendor OAUTH server. You can validate incoming tokens from placements and events
+
 ### Statistics
 
 ```
 Bitrix24 API-methods count: 1145
-Supported in bitrix24-php-sdk methods count: 215
-Coverage percentage: 18.78% 🚀
-Supported in bitrix24-php-sdk methods with batch wrapper count: 23
+Supported in bitrix24-php-sdk methods count: 224
+Coverage percentage: 19.56% 🚀
+Supported in bitrix24-php-sdk methods with batch wrapper count: 29
 ```
 
 <!--

--- a/tests/Integration/Services/Main/Service/MainTest.php
+++ b/tests/Integration/Services/Main/Service/MainTest.php
@@ -79,6 +79,19 @@ class MainTest extends TestCase
     /**
      * @throws BaseException
      * @throws TransportException
+     */
+    public function testGuardValidateCurrentAuthToken(): void
+    {
+        // get service builder with application credentials
+        $serviceBuilder = Fabric::getServiceBuilder(true);
+        // call app.info on OAUTH server
+        $serviceBuilder->getMainScope()->main()->guardValidateCurrentAuthToken();
+        $this->assertTrue(true);
+    }
+
+    /**
+     * @throws BaseException
+     * @throws TransportException
      * @throws UnknownScopeCodeException
      */
     public function testGetAvailableScope(): void


### PR DESCRIPTION
Introduced `guardValidateCurrentAuthToken` in `MainService` to verify current auth tokens using the `app.info` call on the vendor OAUTH server. Updated the `ApiClient` logic to ensure secure token validation for on-premise installations. Added integration test for the new method and updated the changelog accordingly.

| Q             | A                                                                                                                         |
|---------------|---------------------------------------------------------------------------------------------------------------------------|
| Bug fix?      | no                                                                                                                    |
| New feature?  | yes <!-- please update CHANGELOG.md file -->                                                                           |
| Deprecations? | no <!-- please update CHANGELOG.md file -->                                                                           |
| Issues        | Fix #111  <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead --> |
| License       | **MIT**                                                                                                                       |

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally:
 - Always add tests and ensure they pass.
 - For new features, provide some code snippets to help understand usage.
-->