### PR TITLE
task.commentitem.add also requires strict argument order

### DIFF
--- a/src/Core/ApiClient.php
+++ b/src/Core/ApiClient.php
@@ -205,6 +205,7 @@ class ApiClient implements ApiClientInterface
         // todo must be fixed by vendor in API v2
         // part of endpoints required strict order of arguments
         $strictApiMethods = [
+            'task.commentitem.add',
             'task.commentitem.getlist',
             'task.commentitem.update',
             'task.commentitem.getlist',


### PR DESCRIPTION
Hey there, I was just running into the same issue as described in #112. I tried the current dev version but it was missing `task.commentitem.add` in the list of functions that require strict argument order.

| Q             | A                                                                                                                         |
|---------------|---------------------------------------------------------------------------------------------------------------------------|
| Bug fix?      | yes                                                                                                                    |
| New feature?  | no
| Deprecations? |no
| Issues        | Fix #112 
| License       | **MIT**                                                                                                                       |
