### PR TITLE
add PHP 8.4 support

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,3 +9,4 @@
 /phpunit.xml.dist        export-ignore
 /rector.php              export-ignore
 /Makefile                export-ignore
+/var/

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -38,7 +38,7 @@ jobs:
         run: "composer update --no-interaction --no-progress --no-suggest"
 
       - name: "composer-license-checker"
-        run: "make lint-allowed-licenses"
+        run: "vendor/bin/composer-license-checker"
 
       - name: "is allowed licenses check succeeded"
         if: ${{ success() }}

--- a/.github/workflows/php-cs-fixer.yml
+++ b/.github/workflows/php-cs-fixer.yml
@@ -38,7 +38,7 @@ jobs:
         run: "composer update --no-interaction --no-progress --no-suggest"
 
       - name: "PhpCsFixer"
-        run: "make lint-cs-fixer"
+        run: "vendor/bin/php-cs-fixer check --verbose --diff"
 
       - name: "is PhpCsFixer check succeeded"
         if: ${{ success() }}

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -38,7 +38,7 @@ jobs:
         run: "composer update --no-interaction --no-progress --no-suggest"
 
       - name: "PHPStan"
-        run: "make lint-phpstan"
+        run: "vendor/bin/phpstan --memory-limit=2G analyse -vvv"
 
       - name: "is PHPStan check succeeded"
         if: ${{ success() }}

--- a/.github/workflows/rector.yml
+++ b/.github/workflows/rector.yml
@@ -37,7 +37,7 @@ jobs:
           composer update ${{ env.COMPOSER_FLAGS }}
 
       - name: "run Rector"
-        run: "make lint-rector"
+        run: "vendor/bin/rector process --dry-run"
 
       - name: "is Rector check succeeded"
         if: ${{ success() }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 # b24-php-sdk change log
 
-## Unreleased 1.3.0 – 2025.02.09
+## Unreleased 1.3.0 – 2025.02.28
 
 ### Added
-
+- Added **PHP 8.4** [support](https://github.com/bitrix24/b24phpsdk/issues/120) 🚀
 - Added method `Bitrix24\SDK\Services\Main\Service::guardValidateCurrentAuthToken` for validate current auth token with
   api-call `app.info` on vendor OAUTH server.
 - Added support new scope `entity`
@@ -65,6 +65,8 @@
   REST-API, see task «[split cli commands](https://github.com/bitrix24/b24phpsdk/issues/92)»
 - Developer experience: added class `Bitrix24\SDK\Deprecations\DeprecatedMethods` with list of
   all [deprecated methods](https://github.com/bitrix24/b24phpsdk/issues/97)
+- Developer experience: commands from makefile now run inside docker container `php-cli`
+- Developer experience: added cache folder in phpstan config
 
 ### Changed
 

--- a/Makefile
+++ b/Makefile
@@ -93,40 +93,40 @@ build-examples-for-documentation:
 
 # check allowed licenses
 lint-allowed-licenses:
-	vendor/bin/composer-license-checker
+	docker-compose run --rm php-cli vendor/bin/composer-license-checker
 
 # linters & code style
 lint-cs-fixer:
-	vendor/bin/php-cs-fixer check --verbose --diff
+	docker-compose run --rm php-cli vendor/bin/php-cs-fixer check --verbose --diff
 lint-cs-fixer-fix:
-	vendor/bin/php-cs-fixer fix --verbose --diff
+	docker-compose run --rm php-cli vendor/bin/php-cs-fixer fix --verbose --diff
 lint-phpstan:
-	vendor/bin/phpstan --memory-limit=1G analyse -v
+	docker-compose run --rm php-cli vendor/bin/phpstan --memory-limit=2G analyse -vvv
 lint-rector:
-	vendor/bin/rector process --dry-run
+	docker-compose run --rm php-cli vendor/bin/rector process --dry-run
 lint-rector-fix:
-	vendor/bin/rector process
+	docker-compose run --rm php-cli vendor/bin/rector process
 
 # unit tests
 test-unit:
-	vendor/bin/phpunit --testsuite unit_tests --display-warnings
+	docker-compose run --rm php-cli vendor/bin/phpunit --testsuite unit_tests --display-warnings
 
 # integration tests with granularity by api-scope
 test-integration-scope-telephony:
-	vendor/bin/phpunit --testsuite integration_tests_scope_telephony
+	docker-compose run --rm php-cli vendor/bin/phpunit --testsuite integration_tests_scope_telephony
 test-integration-scope-workflows:
-	vendor/bin/phpunit --testsuite integration_tests_scope_workflows
+	docker-compose run --rm php-cli vendor/bin/phpunit --testsuite integration_tests_scope_workflows
 test-integration-scope-im:
-	vendor/bin/phpunit --testsuite integration_tests_scope_im
+	docker-compose run --rm php-cli vendor/bin/phpunit --testsuite integration_tests_scope_im
 test-integration-scope-placement:
-	vendor/bin/phpunit --testsuite integration_tests_scope_placement
+	docker-compose run --rm php-cli vendor/bin/phpunit --testsuite integration_tests_scope_placement
 test-integration-scope-im-open-lines:
-	vendor/bin/phpunit --testsuite integration_tests_scope_im_open_lines
+	docker-compose run --rm php-cli vendor/bin/phpunit --testsuite integration_tests_scope_im_open_lines
 test-integration-scope-user:
-	vendor/bin/phpunit --testsuite integration_tests_scope_user
+	docker-compose run --rm php-cli vendor/bin/phpunit --testsuite integration_tests_scope_user
 test-integration-scope-user-consent:
-	vendor/bin/phpunit --testsuite integration_tests_scope_user_consent
+	docker-compose run --rm php-cli vendor/bin/phpunit --testsuite integration_tests_scope_user_consent
 test-integration-core:
-	vendor/bin/phpunit --testsuite integration_tests_core
+	docker-compose run --rm php-cli vendor/bin/phpunit --testsuite integration_tests_core
 test-integration-scope-entity:
-	vendor/bin/phpunit --testsuite integration_tests_scope_entity
+	docker-compose run --rm php-cli vendor/bin/phpunit --testsuite integration_tests_scope_entity

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     }
   },
   "require": {
-    "php": "8.2.* || 8.3.*",
+    "php": "8.2.* || 8.3.* || 8.4.*",
     "ext-json": "*",
     "ext-curl": "*",
     "ext-intl": "*",
@@ -51,12 +51,12 @@
     "ergebnis/composer-normalize": "^2",
     "fakerphp/faker": "^1",
     "friendsofphp/php-cs-fixer": "^3",
-    "lendable/composer-license-checker": "^1.2",
+    "lendable/composer-license-checker": "^1",
     "monolog/monolog": "^3",
     "nyholm/psr7": "^1.8",
     "openai-php/client": "0.10.*",
     "phpstan/phpstan": "1.11.7",
-    "phpunit/phpunit": "^10 || ^11",
+    "phpunit/phpunit": "^10 || ^11|| ^12",
     "rector/rector": "^1",
     "roave/security-advisories": "dev-master",
     "symfony/debug-bundle": "^6 || ^7",
@@ -64,7 +64,7 @@
     "symfony/stopwatch": "^6 || ^7",
     "symfony/var-dumper": "^6 || ^7",
     "typhoon/reflection": "^0.4",
-    "sentry/sentry":"*"
+    "sentry/sentry":"^4"
   },
   "autoload": {
     "psr-4": {

--- a/docker/php-cli/Dockerfile
+++ b/docker/php-cli/Dockerfile
@@ -1,9 +1,27 @@
+#FROM php:8.3-cli-alpine
+#
+#RUN apk add unzip libpq-dev git icu-dev \
+#    && docker-php-ext-install bcmath intl \
+#    && docker-php-ext-enable bcmath intl
+#
+#RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/bin --filename=composer --quiet
+#
+#ENV COMPOSER_ALLOW_SUPERUSER 1
+
 FROM php:8.3-cli-alpine
 
-RUN apk add unzip libpq-dev git icu-dev \
+# Install system dependencies and PHP extensions
+RUN apk add --no-cache unzip libpq-dev git icu-dev $PHPIZE_DEPS \
     && docker-php-ext-install bcmath intl \
     && docker-php-ext-enable bcmath intl
 
+# Install and enable Excimer extension
+# https://www.mediawiki.org/wiki/Excimer
+RUN pecl install excimer \
+    && docker-php-ext-enable excimer
+
+# Install Composer
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/bin --filename=composer --quiet
 
+# Set Composer environment variable
 ENV COMPOSER_ALLOW_SUPERUSER 1

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -17,6 +17,7 @@ parameters:
     jobSize: 20
     maximumNumberOfProcesses: 8
     minimumNumberOfJobsPerProcess: 2
+  tmpDir: var/temp
   editorUrlTitle: '%%relFile%%:%%line%%'
   editorUrl: 'phpstorm://open?file=%%file%%&line=%%line%%'
   treatPhpDocTypesAsCertain: false

--- a/src/Application/Workflows/Robots/Common/RobotHandlerInterface.php
+++ b/src/Application/Workflows/Robots/Common/RobotHandlerInterface.php
@@ -19,16 +19,11 @@ interface RobotHandlerInterface
 {
     /**
      * Process robot request
-     *
-     * @param RobotRequest $robotRequest
-     * @return RobotResponse
      */
     public function handle(RobotRequest $robotRequest): RobotResponse;
 
     /**
      * Get robot metadata
-     *
-     * @return RobotMetadata
      */
     public function getMetadata(): RobotMetadata;
 }

--- a/src/Application/Workflows/Robots/Common/RobotMetadata.php
+++ b/src/Application/Workflows/Robots/Common/RobotMetadata.php
@@ -15,15 +15,13 @@ namespace Bitrix24\SDK\Application\Workflows\Robots\Common;
 
 final readonly class RobotMetadata
 {
-
-
-    public function isInstalled(mixed $robot):bool
-    {
-        return true;
-    }
-
-    public function equal(RobotMetadata $robotMetadata): bool
-    {
-        return true;
-    }
+//    public function isInstalled(mixed $robot):bool
+//    {
+//        return true;
+//    }
+//
+//    public function equal(RobotMetadata $robotMetadata): bool
+//    {
+//        return true;
+//    }
 }

--- a/src/Application/Workflows/Robots/Common/RobotRequest.php
+++ b/src/Application/Workflows/Robots/Common/RobotRequest.php
@@ -39,9 +39,6 @@ readonly class RobotRequest
 
     /**
      * Create from incoming robot request
-     *
-     * @param IncomingRobotRequest $incomingRobotRequest
-     * @return self
      */
     public function initFromIncomingRobotRequest(IncomingRobotRequest $incomingRobotRequest): self
     {

--- a/src/Application/Workflows/Robots/Events/RobotAdded.php
+++ b/src/Application/Workflows/Robots/Events/RobotAdded.php
@@ -18,11 +18,8 @@ use Symfony\Contracts\EventDispatcher\Event;
 
 class RobotAdded extends Event
 {
-    protected RobotMetadata $robotMetadata;
-
-    public function __construct(RobotMetadata $robotMetadata)
+    public function __construct(protected RobotMetadata $robotMetadata)
     {
-        $this->robotMetadata = $robotMetadata;
     }
 
     public function getRobotMetadata(): RobotMetadata

--- a/src/Application/Workflows/Robots/Service/RobotManager.php
+++ b/src/Application/Workflows/Robots/Service/RobotManager.php
@@ -22,63 +22,49 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 class RobotManager
 {
-    protected EventDispatcherInterface $eventDispatcher;
-    protected LoggerInterface $logger;
-
     public function __construct(
-        EventDispatcherInterface $eventDispatcher,
-        LoggerInterface $logger
+        protected EventDispatcherInterface $eventDispatcher,
+        protected LoggerInterface $logger
     ) {
-        $this->eventDispatcher = $eventDispatcher;
-        $this->logger = $logger;
     }
 
-    /**
-     * @param ServiceBuilder $serviceBuilder
-     * @param array $robotsMetadata
-     * @param string $defaultHandlerUrl
-     * @param int|null $defaultB24UserId
-     * @return void
-     * @throws BaseException
-     * @throws TransportException
-     */
-    public function install(
+   public function install(
         ServiceBuilder $serviceBuilder,
         array $robotsMetadata,
         ?string $defaultHandlerUrl,
         ?int $defaultB24UserId
     ): void {
-        // todo check duplicates in robots metadata
-
-
-        // get installed robots
-        $installedRobots = $serviceBuilder->getBizProcScope()->robot()->list();
-
-
-        // skip already installed robots
-        // todo uninstall robots for update if metadata are not equal
-
-        // install robots
-        // todo add in batch mode
-        foreach ($robotsMetadata as $robotMetadata) {
-            $isAdded = $serviceBuilder->getBizProcScope()->robot()->add(
-                $robotMetadata->code,
-                $robotMetadata->handlerUrl,
-                $robotMetadata->b24AuthUserId,
-                $robotMetadata->localizedRobotName,
-                $robotMetadata->isUseSubscription,
-                $robotMetadata->properties,
-                $robotMetadata->isUsePlacement,
-                $robotMetadata->returnProperties
-            )->isSuccess();
-
-            $this->logger->debug('RobotManager.install.robotAdded', [
-                'code' => $robotMetadata->code,
-            ]);
-
-            if ($isAdded) {
-                $this->eventDispatcher->dispatch(new RobotAdded($robotMetadata));
-            }
-        }
+//        // todo check duplicates in robots metadata
+//
+//
+//        // get installed robots
+//        $installedRobots = $serviceBuilder->getBizProcScope()->robot()->list();
+//
+//
+//        // skip already installed robots
+//        // todo uninstall robots for update if metadata are not equal
+//
+//        // install robots
+//        // todo add in batch mode
+//        foreach ($robotsMetadata as $robotMetadata) {
+//            $isAdded = $serviceBuilder->getBizProcScope()->robot()->add(
+//                $robotMetadata->code,
+//                $robotMetadata->handlerUrl,
+//                $robotMetadata->b24AuthUserId,
+//                $robotMetadata->localizedRobotName,
+//                $robotMetadata->isUseSubscription,
+//                $robotMetadata->properties,
+//                $robotMetadata->isUsePlacement,
+//                $robotMetadata->returnProperties
+//            )->isSuccess();
+//
+//            $this->logger->debug('RobotManager.install.robotAdded', [
+//                'code' => $robotMetadata->code,
+//            ]);
+//
+//            if ($isAdded) {
+//                $this->eventDispatcher->dispatch(new RobotAdded($robotMetadata));
+//            }
+//        }
     }
 }


### PR DESCRIPTION
Replaced direct execution of PHP tools with dockerized commands in the Makefile for consistency and better environment encapsulation. Added support for PHP 8.4 and updated dependencies. Improved developer experience with updated caching and streamlined workflow configurations.

| Q             | A                                                                                                                         |
|---------------|---------------------------------------------------------------------------------------------------------------------------|
| Bug fix?      | no                                                                                                                    |
| New feature?  | yes <!-- please update CHANGELOG.md file -->                                                                           |
| Deprecations? | yes <!-- please update CHANGELOG.md file -->                                                                           |
| Issues        | Fix #120 <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead --> |
| License       | **MIT**                                                                                                                       |

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally:
 - Always add tests and ensure they pass.
 - For new features, provide some code snippets to help understand usage.
-->