### PR TITLE
Add repository flusher to installation repository tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased 1.3.0 – 2025.02.28
 
 ### Added
+
 - Added **PHP 8.4** [support](https://github.com/bitrix24/b24phpsdk/issues/120) 🚀
 - Added method `Bitrix24\SDK\Services\Main\Service::guardValidateCurrentAuthToken` for validate current auth token with
   api-call `app.info` on vendor OAUTH server.
@@ -74,7 +75,8 @@
   for task «[split cli commands](https://github.com/bitrix24/b24phpsdk/issues/92)»
 - Changed method signature `Bitrix24\SDK\Application\Contracts\Bitrix24Accounts\Entity::updateApplicationVersion`, for
   task «[add bitrixUserId and AuthToken](https://github.com/bitrix24/b24phpsdk/issues/115)»
-- Developer experience: webhook example moved to repository [bitrix24/b24sdk-examples](https://github.com/bitrix24/b24sdk-examples/tree/main/php/quick-start/simple/02-work-with-webhook)
+- Developer experience: webhook example moved to
+  repository [bitrix24/b24sdk-examples](https://github.com/bitrix24/b24sdk-examples/tree/main/php/quick-start/simple/02-work-with-webhook)
 
 ### Fixed
 
@@ -84,6 +86,7 @@
   `entity.item.update`, [see details](https://github.com/bitrix24/b24phpsdk/issues/53)
 - Fixed errors in `Bitrix24\SDK\Core\ApiClient` for methods with strict arguments
   order, [see details](https://github.com/bitrix24/b24phpsdk/issues/101)
+- Fixed errors in `ApplicationInstallationRepositoryInterfaceTest` for work with storage [see details](https://github.com/bitrix24/b24phpsdk/issues/123)
 
 ### Security
 
@@ -91,8 +94,10 @@
   api-call `app.info` on vendor OAUTH server. You can validate incoming tokens from placements and events
 
 ### Removed
-- Developer experience: removed example webhook-error-handling, see example [02-work-with-webhook](https://github.com/bitrix24/b24sdk-examples/tree/main/php/quick-start/simple/02-work-with-webhook)
- 
+
+- Developer experience: removed example webhook-error-handling, see
+  example [02-work-with-webhook](https://github.com/bitrix24/b24sdk-examples/tree/main/php/quick-start/simple/02-work-with-webhook)
+
 ### Statistics
 
 ```

--- a/tests/Application/Contracts/ApplicationInstallations/Repository/ApplicationInstallationRepositoryInterfaceTest.php
+++ b/tests/Application/Contracts/ApplicationInstallations/Repository/ApplicationInstallationRepositoryInterfaceTest.php
@@ -20,6 +20,7 @@ use Bitrix24\SDK\Application\Contracts\ApplicationInstallations\Exceptions\Appli
 use Bitrix24\SDK\Application\Contracts\ApplicationInstallations\Repository\ApplicationInstallationRepositoryInterface;
 use Bitrix24\SDK\Application\PortalLicenseFamily;
 use Bitrix24\SDK\Core\Exceptions\InvalidArgumentException;
+use Bitrix24\SDK\Tests\Application\Contracts\TestRepositoryFlusherInterface;
 use Carbon\CarbonImmutable;
 use DateInterval;
 use DateTime;
@@ -50,7 +51,7 @@ abstract class ApplicationInstallationRepositoryInterfaceTest extends TestCase
     ): ApplicationInstallationInterface;
 
     abstract protected function createApplicationInstallationRepositoryImplementation(): ApplicationInstallationRepositoryInterface;
-
+    abstract protected function createRepositoryFlusherImplementation(): TestRepositoryFlusherInterface;
     /**
      * @throws ApplicationInstallationNotFoundException
      */
@@ -73,9 +74,11 @@ abstract class ApplicationInstallationRepositoryInterfaceTest extends TestCase
     ): void
     {
         $appInstallationRepo = $this->createApplicationInstallationRepositoryImplementation();
+        $flusher = $this->createRepositoryFlusherImplementation();
 
         $installation = $this->createApplicationInstallationImplementation($uuid, $applicationInstallationStatus, $createdAt, $updatedAt, $bitrix24AccountUuid, $applicationStatus, $portalLicenseFamily, $portalUsersCount, $clientContactPersonUuid, $partnerContactPersonUuid, $partnerUuid, $externalId);
         $appInstallationRepo->save($installation);
+        $flusher->flush();
 
         $this->assertEquals($installation, $appInstallationRepo->getById($installation->getId()));
     }
@@ -99,9 +102,11 @@ abstract class ApplicationInstallationRepositoryInterfaceTest extends TestCase
     ): void
     {
         $appInstallationRepo = $this->createApplicationInstallationRepositoryImplementation();
+        $flusher = $this->createRepositoryFlusherImplementation();
 
         $installation = $this->createApplicationInstallationImplementation($uuid, $applicationInstallationStatus, $createdAt, $updatedAt, $bitrix24AccountUuid, $applicationStatus, $portalLicenseFamily, $portalUsersCount, $clientContactPersonUuid, $partnerContactPersonUuid, $partnerUuid, $externalId);
         $appInstallationRepo->save($installation);
+        $flusher->flush();
 
         $this->assertEquals($installation, $appInstallationRepo->getById($installation->getId()));
     }
@@ -153,6 +158,7 @@ abstract class ApplicationInstallationRepositoryInterfaceTest extends TestCase
     ): void
     {
         $appInstallationRepo = $this->createApplicationInstallationRepositoryImplementation();
+        $flusher = $this->createRepositoryFlusherImplementation();
 
         $installation = $this->createApplicationInstallationImplementation($uuid, $applicationInstallationStatus, $createdAt, $updatedAt, $bitrix24AccountUuid, $applicationStatus, $portalLicenseFamily, $portalUsersCount, $clientContactPersonUuid, $partnerContactPersonUuid, $partnerUuid, $externalId);
         // successfully finish installation flow
@@ -162,9 +168,11 @@ abstract class ApplicationInstallationRepositoryInterfaceTest extends TestCase
         // we receive ON_APPLICATION_UNINSTALL event and mark application installation as uninstalled: status = deleted
         $installation->applicationUninstalled();
         $appInstallationRepo->save($installation);
+        $flusher->flush();
 
         // if we want we can delete application installation from repository
         $appInstallationRepo->delete($installation->getId());
+        $flusher->flush();
 
         $this->expectException(ApplicationInstallationNotFoundException::class);
         $appInstallationRepo->getById($installation->getId());
@@ -217,9 +225,11 @@ abstract class ApplicationInstallationRepositoryInterfaceTest extends TestCase
     ): void
     {
         $appInstallationRepo = $this->createApplicationInstallationRepositoryImplementation();
+        $flusher = $this->createRepositoryFlusherImplementation();
 
         $installation = $this->createApplicationInstallationImplementation($uuid, $applicationInstallationStatus, $createdAt, $updatedAt, $bitrix24AccountUuid, $applicationStatus, $portalLicenseFamily, $portalUsersCount, $clientContactPersonUuid, $partnerContactPersonUuid, $partnerUuid, $externalId);
         $appInstallationRepo->save($installation);
+        $flusher->flush();
 
         $this->expectException(InvalidArgumentException::class);
         $appInstallationRepo->delete($installation->getId());
@@ -244,9 +254,11 @@ abstract class ApplicationInstallationRepositoryInterfaceTest extends TestCase
     ): void
     {
         $appInstallationRepo = $this->createApplicationInstallationRepositoryImplementation();
+        $flusher = $this->createRepositoryFlusherImplementation();
 
         $installation = $this->createApplicationInstallationImplementation($uuid, $applicationInstallationStatus, $createdAt, $updatedAt, $bitrix24AccountUuid, $applicationStatus, $portalLicenseFamily, $portalUsersCount, $clientContactPersonUuid, $partnerContactPersonUuid, $partnerUuid, $externalId);
         $appInstallationRepo->save($installation);
+        $flusher->flush();
 
         $this->assertEquals([$installation], $appInstallationRepo->findByBitrix24AccountId($bitrix24AccountUuid));
     }
@@ -296,11 +308,13 @@ abstract class ApplicationInstallationRepositoryInterfaceTest extends TestCase
     ): void
     {
         $appInstallationRepo = $this->createApplicationInstallationRepositoryImplementation();
+        $flusher = $this->createRepositoryFlusherImplementation();
 
         $installation = $this->createApplicationInstallationImplementation($uuid, $applicationInstallationStatus, $createdAt, $updatedAt, $bitrix24AccountUuid, $applicationStatus, $portalLicenseFamily, $portalUsersCount, $clientContactPersonUuid, $partnerContactPersonUuid, $partnerUuid, $externalId);
         $externalId = Uuid::v7()->toRfc4122();
         $installation->setExternalId($externalId);
         $appInstallationRepo->save($installation);
+        $flusher->flush();
 
         $this->assertEquals([$installation], $appInstallationRepo->findByExternalId($externalId));
     }

--- a/tests/Unit/Application/Contracts/ApplicationInstallations/Repository/InMemoryApplicationInstallationRepositoryImplementationTest.php
+++ b/tests/Unit/Application/Contracts/ApplicationInstallations/Repository/InMemoryApplicationInstallationRepositoryImplementationTest.php
@@ -19,6 +19,8 @@ use Bitrix24\SDK\Application\Contracts\ApplicationInstallations\Entity\Applicati
 use Bitrix24\SDK\Application\Contracts\ApplicationInstallations\Repository\ApplicationInstallationRepositoryInterface;
 use Bitrix24\SDK\Application\PortalLicenseFamily;
 use Bitrix24\SDK\Tests\Application\Contracts\ApplicationInstallations\Repository\ApplicationInstallationRepositoryInterfaceTest;
+use Bitrix24\SDK\Tests\Application\Contracts\NullableFlusher;
+use Bitrix24\SDK\Tests\Application\Contracts\TestRepositoryFlusherInterface;
 use Bitrix24\SDK\Tests\Integration\Fabric;
 use Bitrix24\SDK\Tests\Unit\Application\Contracts\ApplicationInstallations\Entity\ApplicationInstallationReferenceEntityImplementation;
 use Carbon\CarbonImmutable;
@@ -45,6 +47,11 @@ class InMemoryApplicationInstallationRepositoryImplementationTest extends Applic
             $partnerUuid,
             $externalId,
         );
+    }
+
+    protected function createRepositoryFlusherImplementation(): TestRepositoryFlusherInterface
+    {
+        return new NullableFlusher();
     }
 
     protected function createApplicationInstallationRepositoryImplementation(): ApplicationInstallationRepositoryInterface


### PR DESCRIPTION
Introduced a `TestRepositoryFlusherInterface` and integrated flushing logic into application installation repository tests. This ensures proper storage synchronization for tested operations, improving reliability and accuracy of test assertions.

| Q             | A                                                                                                                         |
|---------------|---------------------------------------------------------------------------------------------------------------------------|
| Bug fix?      | yes                                                                                                                    |
| New feature?  | no <!-- please update CHANGELOG.md file -->                                                                           |
| Deprecations? |no <!-- please update CHANGELOG.md file -->                                                                           |
| Issues        | Fix #123  <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead --> |
| License       | **MIT**                                                                                                                       |

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally:
 - Always add tests and ensure they pass.
 - For new features, provide some code snippets to help understand usage.
-->