### PR TITLE
Feature/134 сomplete scope crm vol 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 ## Unreleased 1.3.0 – 2025.03.31
 
 ### Added
+- Added service `Services\AI\Engine\Service\Type` with support methods:
+    - `crm.activity.type.add` - method registers a custom activity type with a name and icon
+    - `crm.activity.type.delete` - delete a custom activity type
+    - `crm.activity.type.list` - get a list of custom task types
+- Added service `Services\AI\Engine\Service\Communication` with support methods:
+    - `crm.activity.communication.fields` - get a description of the communication
 
 - Added **PHP 8.4** [support](https://github.com/bitrix24/b24phpsdk/issues/120) 🚀
 - Added method `Bitrix24\SDK\Services\Main\Service::guardValidateCurrentAuthToken` for validate current auth token with

--- a/src/Services/CRM/Activity/Service/Communication.php
+++ b/src/Services/CRM/Activity/Service/Communication.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * This file is part of the bitrix24-php-sdk package.
+ *
+ * © Maksim Mesilov <mesilov.maxim@gmail.com>
+ *
+ * For the full copyright and license information, please view the MIT-LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Bitrix24\SDK\Services\CRM\Activity\Service;
+
+use Bitrix24\SDK\Attributes\ApiEndpointMetadata;
+use Bitrix24\SDK\Attributes\ApiServiceMetadata;
+use Bitrix24\SDK\Core\Contracts\CoreInterface;
+use Bitrix24\SDK\Core\Credentials\Scope;
+use Bitrix24\SDK\Core\Exceptions\BaseException;
+use Bitrix24\SDK\Core\Exceptions\TransportException;
+use Bitrix24\SDK\Services\AbstractService;
+use Bitrix24\SDK\Core\Result\FieldsResult;
+use Psr\Log\LoggerInterface;
+
+#[ApiServiceMetadata(new Scope(['crm']))]
+class Communication extends AbstractService
+{
+    public Batch $batch;
+
+    /**
+     * Contact constructor.
+     *
+     * @param Batch $batch
+     * @param CoreInterface $core
+     * @param LoggerInterface $log
+     */
+    public function __construct(Batch $batch, CoreInterface $core, LoggerInterface $log)
+    {
+        parent::__construct($core, $log);
+        $this->batch = $batch;
+    }
+
+    /**
+     * Get a description of the communication.
+     *
+     * @link https://apidocs.bitrix24.ru/api-reference/crm/timeline/activities/activity-base/crm-activity-communication-fields.html
+     *
+     * @return FieldsResult
+     * @throws BaseException
+     * @throws TransportException
+     */
+    #[ApiEndpointMetadata(
+        'crm.activity.communication.fields',
+        'https://apidocs.bitrix24.ru/api-reference/crm/timeline/activities/activity-base/crm-activity-communication-fields.html',
+        'Get a description of the communication.'
+    )]
+    public function fields(): FieldsResult
+    {
+        return new FieldsResult($this->core->call('crm.activity.communication.fields'));
+    }
+}

--- a/src/Services/CRM/Activity/Service/Type.php
+++ b/src/Services/CRM/Activity/Service/Type.php
@@ -26,7 +26,7 @@ use Bitrix24\SDK\Services\CRM\Activity\Result\ActivitiesResult;
 use Psr\Log\LoggerInterface;
 
 #[ApiServiceMetadata(new Scope(['crm']))]
-class Type extends AbstractService
+class ActivityType extends AbstractService
 {
     public Batch $batch;
 
@@ -101,7 +101,7 @@ class Type extends AbstractService
     #[ApiEndpointMetadata(
         'crm.activity.type.add',
         'https://apidocs.bitrix24.ru/api-reference/crm/timeline/activities/types/crm-activity-type-add',
-        'The method registers a custom case type with a name and icon.'
+        'The method registers a custom activity type with a name and icon.'
     )]
     public function add(array $fields): AddedItemResult
     {
@@ -129,7 +129,7 @@ class Type extends AbstractService
     #[ApiEndpointMetadata(
         'crm.activity.type.delete',
         'https://apidocs.bitrix24.ru/api-reference/crm/timeline/activities/types/crm-activity-type-delete.html',
-        'Delete a custom case type.'
+        'Delete a custom activity type.'
     )]
     public function delete(int $itemId): DeletedItemResult
     {

--- a/src/Services/CRM/Activity/Service/Type.php
+++ b/src/Services/CRM/Activity/Service/Type.php
@@ -1,0 +1,166 @@
+<?php
+
+/**
+ * This file is part of the bitrix24-php-sdk package.
+ *
+ * © Maksim Mesilov <mesilov.maxim@gmail.com>
+ *
+ * For the full copyright and license information, please view the MIT-LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Bitrix24\SDK\Services\CRM\Activity\Service;
+
+use Bitrix24\SDK\Attributes\ApiEndpointMetadata;
+use Bitrix24\SDK\Attributes\ApiServiceMetadata;
+use Bitrix24\SDK\Core\Contracts\CoreInterface;
+use Bitrix24\SDK\Core\Credentials\Scope;
+use Bitrix24\SDK\Core\Exceptions\BaseException;
+use Bitrix24\SDK\Core\Exceptions\TransportException;
+use Bitrix24\SDK\Core\Result\AddedItemResult;
+use Bitrix24\SDK\Core\Result\DeletedItemResult;
+use Bitrix24\SDK\Services\AbstractService;
+use Bitrix24\SDK\Services\CRM\Activity\Result\ActivitiesResult;
+use Psr\Log\LoggerInterface;
+
+#[ApiServiceMetadata(new Scope(['crm']))]
+class Type extends AbstractService
+{
+    public Batch $batch;
+
+    /**
+     * Contact constructor.
+     *
+     * @param Batch $batch
+     * @param CoreInterface $core
+     * @param LoggerInterface $log
+     */
+    public function __construct(Batch $batch, CoreInterface $core, LoggerInterface $log)
+    {
+        parent::__construct($core, $log);
+        $this->batch = $batch;
+    }
+
+    /**
+     * The method registers a custom case type with a name and icon.
+     *
+     * @link https://apidocs.bitrix24.ru/api-reference/crm/timeline/activities/types/crm-activity-type-add
+     *
+     * @param array{
+     *   ID?: int,
+     *   OWNER_ID?: int,
+     *   OWNER_TYPE_ID?: int,
+     *   TYPE_ID?: int,
+     *   PROVIDER_ID?: string,
+     *   PROVIDER_TYPE_ID?: string,
+     *   PROVIDER_GROUP_ID?: string,
+     *   ASSOCIATED_ENTITY_ID?: int,
+     *   SUBJECT?: string,
+     *   START_TIME?: string,
+     *   END_TIME?: string,
+     *   DEADLINE?: string,
+     *   COMPLETED?: string,
+     *   STATUS?: string,
+     *   RESPONSIBLE_ID?: string,
+     *   PRIORITY?: string,
+     *   NOTIFY_TYPE?: string,
+     *   NOTIFY_VALUE?: int,
+     *   DESCRIPTION?: string,
+     *   DESCRIPTION_TYPE?: string,
+     *   DIRECTION?: string,
+     *   LOCATION?: string,
+     *   CREATED?: string,
+     *   AUTHOR_ID?: string,
+     *   LAST_UPDATED?: string,
+     *   EDITOR_ID?: string,
+     *   SETTINGS?: string,
+     *   ORIGIN_ID?: string,
+     *   ORIGINATOR_ID?: string,
+     *   RESULT_STATUS?: int,
+     *   RESULT_STREAM?: int,
+     *   RESULT_SOURCE_ID?: string,
+     *   PROVIDER_PARAMS?: string,
+     *   PROVIDER_DATA?: string,
+     *   RESULT_MARK?: int,
+     *   RESULT_VALUE?: string,
+     *   RESULT_SUM?: string,
+     *   RESULT_CURRENCY_ID?: string,
+     *   AUTOCOMPLETE_RULE?: int,
+     *   BINDINGS?: string,
+     *   COMMUNICATIONS?: string,
+     *   FILES?: string,
+     *   WEBDAV_ELEMENTS?: string,
+     *   } $fields
+     *
+     * @return AddedItemResult
+     * @throws BaseException
+     * @throws TransportException
+     */
+    #[ApiEndpointMetadata(
+        'crm.activity.type.add',
+        'https://apidocs.bitrix24.ru/api-reference/crm/timeline/activities/types/crm-activity-type-add',
+        'The method registers a custom case type with a name and icon.'
+    )]
+    public function add(array $fields): AddedItemResult
+    {
+        return new AddedItemResult(
+            $this->core->call(
+                'crm.activity.type.add',
+                [
+                    'fields' => $fields,
+                ]
+            )
+        );
+    }
+
+    /**
+     * Delete a custom case type.
+     *
+     * @link https://apidocs.bitrix24.ru/api-reference/crm/timeline/activities/types/crm-activity-type-delete.html
+     *
+     * @param int $itemId
+     *
+     * @return DeletedItemResult
+     * @throws BaseException
+     * @throws TransportException
+     */
+    #[ApiEndpointMetadata(
+        'crm.activity.type.delete',
+        'https://apidocs.bitrix24.ru/api-reference/crm/timeline/activities/types/crm-activity-type-delete.html',
+        'Delete a custom case type.'
+    )]
+    public function delete(int $itemId): DeletedItemResult
+    {
+        return new DeletedItemResult(
+            $this->core->call(
+                'crm.activity.type.delete',
+                [
+                    'TYPE_ID' => $itemId,
+                ]
+            )
+        );
+    }
+
+    /**
+     * Get a list of custom task types.
+     *
+     * @link https://apidocs.bitrix24.ru/api-reference/crm/timeline/activities/types/crm-activity-type-list.html
+     *
+     * @return ActivitiesResult
+     * @throws BaseException
+     * @throws TransportException
+     */
+    #[ApiEndpointMetadata(
+        'crm.activity.type.list',
+        'https://apidocs.bitrix24.ru/api-reference/crm/timeline/activities/types/crm-activity-type-list.html',
+        'Get a list of custom task types.'
+    )]
+    public function list(): ActivitiesResult
+    {
+        return new ActivitiesResult(
+            $this->core->call('crm.activity.type.list')
+        );
+    }
+}

--- a/tests/Integration/Services/CRM/Activity/Service/TypeTest.php
+++ b/tests/Integration/Services/CRM/Activity/Service/TypeTest.php
@@ -1,0 +1,118 @@
+<?php
+
+/**
+ * This file is part of the bitrix24-php-sdk package.
+ *
+ * © Maksim Mesilov <mesilov.maxim@gmail.com>
+ *
+ * For the full copyright and license information, please view the MIT-LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Bitrix24\SDK\Tests\Integration\Services\CRM\Activity\Service;
+
+use Bitrix24\SDK\Core\Exceptions\BaseException;
+use Bitrix24\SDK\Core\Exceptions\TransportException;
+use Bitrix24\SDK\Services\CRM\Activity\ActivityContentType;
+use Bitrix24\SDK\Services\CRM\Activity\ActivityDirectionType;
+use Bitrix24\SDK\Services\CRM\Activity\Result\ActivityItemResult;
+use Bitrix24\SDK\Services\CRM\Activity\Service\Activity;
+use Bitrix24\SDK\Services\CRM\Activity\ActivityType;
+use Bitrix24\SDK\Services\CRM\Contact\Service\Contact;
+use Bitrix24\SDK\Services\CRM\Deal\Result\DealItemResult;
+use Bitrix24\SDK\Services\CRM\Deal\Result\DealProductRowItemResult;
+use Bitrix24\SDK\Tests\Builders\DemoDataGenerator;
+use Bitrix24\SDK\Tests\Integration\Fabric;
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\CoversMethod;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Typhoon\Reflection\TyphoonReflector;
+use Bitrix24\SDK\Tests\CustomAssertions\CustomBitrix24Assertions;
+use Bitrix24\SDK\Core;
+
+#[CoversClass(Type::class)]
+#[CoversMethod(Type::class, 'add')]
+#[CoversMethod(Type::class, 'delete')]
+#[CoversMethod(Type::class, 'list')]
+class TypeTest extends TestCase
+{
+    use CustomBitrix24Assertions;
+
+    private ActivityType $activityTypeService;
+
+    public function testAllSystemFieldsAnnotated(): void
+    {
+        $propListFromApi = (new Core\Fields\FieldsFilter())->filterSystemFields(array_keys($this->activityTypeService->fields()->getFieldsDescription()));
+        $this->assertBitrix24AllResultItemFieldsAnnotated($propListFromApi, ActivityItemResult::class);
+    }
+
+    public function testAllSystemFieldsHasValidTypeAnnotation():void
+    {
+        $this->assertBitrix24AllResultItemFieldsHasValidTypeAnnotation(
+            $this->activityTypeService->fields()->getFieldsDescription(),
+            ActivityItemResult::class);
+    }
+
+    /**
+     * @throws BaseException
+     * @throws TransportException
+     */
+    public function testAdd(): void
+    {
+        $activityTypeId = $this->activityTypeService->add(
+            [
+                'TYPE_ID' => 'CALL',
+                'NAME' => 'TestActivityType',
+                'IS_CONFIGURABLE_TYPE' => 'N'
+            ]
+        )->getId();
+        // successfully add activity type
+        $this->assertTrue(true);
+    }
+
+    /**
+     * @throws BaseException
+     * @throws TransportException
+     */
+    public function testDelete(): void
+    {
+        $activityTypeId = $this->activityTypeService->add(
+            [
+                'TYPE_ID' => 'CALL',
+                'NAME' => 'TestActivityType',
+                'IS_CONFIGURABLE_TYPE' => 'N'
+            ]
+        )->getId();
+        
+        $this->assertTrue($this->activityTypeService->delete($activityTypeId)->isSuccess());
+    }
+
+    /**
+     * @throws BaseException
+     * @throws TransportException
+     */
+    public function testList(): void
+    {
+        $newActivity = [];
+        for ($i = 0; $i < 3; $i++) {
+            $newActivityType[$i] = [
+                'TYPE_ID' => 'CALL',
+                'NAME' => "TestActivityType_$i",
+                'IS_CONFIGURABLE_TYPE' => 'N'
+            ];
+
+            $this->activityId[] = $this->activityTypeService->add($newActivityType[$i])->getId();;
+        }
+
+        $res = $this->activityTypeService->list();
+
+        // Что за getActivities ?
+        // Скорее всего, тут должно быть не getActivities
+        $isResCountGreatherThenZero = (count($res->getActivities()) > 0) ? true : fasle;
+
+        $this->assertTrue($isResCountGreatherThenZero);
+    }
+}


### PR DESCRIPTION
| Q             | A                                                                                                                         |
|---------------|---------------------------------------------------------------------------------------------------------------------------|
| Bug fix?      | no                                                                                                                    |
| New feature?  | yes                                                                          |
| Deprecations? | no                                                                          |
| Issues        | Feature #134                                                                |
| License       | **MIT**                                                                                                                       |

- Added service `Services\AI\Engine\Service\Type` with support methods:
    - `crm.activity.type.add` - method registers a custom activity type with a name and icon
    - `crm.activity.type.delete` - delete a custom activity type
    - `crm.activity.type.list` - get a list of custom task types
- Added service `Services\AI\Engine\Service\Communication` with support methods:
    - `crm.activity.communication.fields` - get a description of the communication