### PR TITLE
feat: Make Bitrix24 partner ID read-only (issue #305)

### DIFF
--- a/src/Application/Contracts/Bitrix24Partners/Entity/Bitrix24PartnerInterface.php
+++ b/src/Application/Contracts/Bitrix24Partners/Entity/Bitrix24PartnerInterface.php
@@ -144,15 +144,10 @@ interface Bitrix24PartnerInterface
 
     /**
      * Get bitrix24 partner id
+     *
+     * @return positive-int bitrix24 partner id from vendor site
      */
-    public function getBitrix24PartnerId(): ?int;
-
-    /**
-     * Set bitrix24 partner id
-     * @param positive-int|null $bitrix24PartnerId bitrix24 partner id from vendor site
-     * @throws InvalidArgumentException
-     */
-    public function setBitrix24PartnerId(?int $bitrix24PartnerId): void;
+    public function getBitrix24PartnerId(): int;
 
     /**
      * Get open line id

--- a/src/Application/Contracts/Bitrix24Partners/Events/Bitrix24PartnerPartnerIdChangedEvent.php
+++ b/src/Application/Contracts/Bitrix24Partners/Events/Bitrix24PartnerPartnerIdChangedEvent.php
@@ -17,6 +17,10 @@ use Carbon\CarbonImmutable;
 use Symfony\Component\Uid\Uuid;
 use Symfony\Contracts\EventDispatcher\Event;
 
+/**
+ * @deprecated This event is deprecated since version 1.9.0 and will be removed in version 2.0.0.
+ *             The Bitrix24 partner ID is now read-only and can only be set during entity construction.
+ */
 class Bitrix24PartnerPartnerIdChangedEvent extends Event
 {
     public function __construct(

--- a/tests/Application/Contracts/Bitrix24Partners/Entity/Bitrix24PartnerInterfaceTest.php
+++ b/tests/Application/Contracts/Bitrix24Partners/Entity/Bitrix24PartnerInterfaceTest.php
@@ -40,7 +40,7 @@ abstract class Bitrix24PartnerInterfaceTest extends TestCase
         CarbonImmutable       $updatedAt,
         Bitrix24PartnerStatus $bitrix24PartnerStatus,
         string                $title,
-        ?int                  $bitrix24PartnerId,
+        int                   $bitrix24PartnerId,
         ?string               $site,
         ?PhoneNumber          $phoneNumber,
         ?string               $email,
@@ -57,7 +57,7 @@ abstract class Bitrix24PartnerInterfaceTest extends TestCase
         CarbonImmutable       $updatedAt,
         Bitrix24PartnerStatus $bitrix24PartnerStatus,
         string                $title,
-        ?int                  $bitrix24PartnerId,
+        int                   $bitrix24PartnerId,
         ?string               $site,
         ?PhoneNumber          $phoneNumber,
         ?string               $email,
@@ -79,7 +79,7 @@ abstract class Bitrix24PartnerInterfaceTest extends TestCase
         CarbonImmutable       $updatedAt,
         Bitrix24PartnerStatus $bitrix24PartnerStatus,
         string                $title,
-        ?int                  $bitrix24PartnerId,
+        int                   $bitrix24PartnerId,
         ?string               $site,
         ?PhoneNumber          $phoneNumber,
         ?string               $email,
@@ -104,7 +104,7 @@ abstract class Bitrix24PartnerInterfaceTest extends TestCase
         CarbonImmutable       $updatedAt,
         Bitrix24PartnerStatus $bitrix24PartnerStatus,
         string                $title,
-        ?int                  $bitrix24PartnerId,
+        int                   $bitrix24PartnerId,
         ?string               $site,
         ?PhoneNumber          $phoneNumber,
         ?string               $email,
@@ -127,7 +127,7 @@ abstract class Bitrix24PartnerInterfaceTest extends TestCase
         CarbonImmutable       $updatedAt,
         Bitrix24PartnerStatus $bitrix24PartnerStatus,
         string                $title,
-        ?int                  $bitrix24PartnerId,
+        int                   $bitrix24PartnerId,
         ?string               $site,
         ?PhoneNumber          $phoneNumber,
         ?string               $email,
@@ -155,7 +155,7 @@ abstract class Bitrix24PartnerInterfaceTest extends TestCase
         CarbonImmutable       $updatedAt,
         Bitrix24PartnerStatus $bitrix24PartnerStatus,
         string                $title,
-        ?int                  $bitrix24PartnerId,
+        int                   $bitrix24PartnerId,
         ?string               $site,
         ?PhoneNumber          $phoneNumber,
         ?string               $email,
@@ -178,7 +178,7 @@ abstract class Bitrix24PartnerInterfaceTest extends TestCase
         CarbonImmutable       $updatedAt,
         Bitrix24PartnerStatus $bitrix24PartnerStatus,
         string                $title,
-        ?int                  $bitrix24PartnerId,
+        int                   $bitrix24PartnerId,
         ?string               $site,
         ?PhoneNumber          $phoneNumber,
         ?string               $email,
@@ -201,7 +201,7 @@ abstract class Bitrix24PartnerInterfaceTest extends TestCase
         CarbonImmutable       $updatedAt,
         Bitrix24PartnerStatus $bitrix24PartnerStatus,
         string                $title,
-        ?int                  $bitrix24PartnerId,
+        int                   $bitrix24PartnerId,
         ?string               $site,
         ?PhoneNumber          $phoneNumber,
         ?string               $email,
@@ -226,7 +226,7 @@ abstract class Bitrix24PartnerInterfaceTest extends TestCase
         CarbonImmutable       $updatedAt,
         Bitrix24PartnerStatus $bitrix24PartnerStatus,
         string                $title,
-        ?int                  $bitrix24PartnerId,
+        int                   $bitrix24PartnerId,
         ?string               $site,
         ?PhoneNumber          $phoneNumber,
         ?string               $email,
@@ -259,7 +259,7 @@ abstract class Bitrix24PartnerInterfaceTest extends TestCase
         CarbonImmutable       $updatedAt,
         Bitrix24PartnerStatus $bitrix24PartnerStatus,
         string                $title,
-        ?int                  $bitrix24PartnerId,
+        int                   $bitrix24PartnerId,
         ?string               $site,
         ?PhoneNumber          $phoneNumber,
         ?string               $email,
@@ -288,7 +288,7 @@ abstract class Bitrix24PartnerInterfaceTest extends TestCase
         CarbonImmutable       $updatedAt,
         Bitrix24PartnerStatus $bitrix24PartnerStatus,
         string                $title,
-        ?int                  $bitrix24PartnerId,
+        int                   $bitrix24PartnerId,
         ?string               $site,
         ?PhoneNumber          $phoneNumber,
         ?string               $email,
@@ -317,7 +317,7 @@ abstract class Bitrix24PartnerInterfaceTest extends TestCase
         CarbonImmutable       $updatedAt,
         Bitrix24PartnerStatus $bitrix24PartnerStatus,
         string                $title,
-        ?int                  $bitrix24PartnerId,
+        int                   $bitrix24PartnerId,
         ?string               $site,
         ?PhoneNumber          $phoneNumber,
         ?string               $email,
@@ -339,7 +339,7 @@ abstract class Bitrix24PartnerInterfaceTest extends TestCase
         CarbonImmutable       $updatedAt,
         Bitrix24PartnerStatus $bitrix24PartnerStatus,
         string                $title,
-        ?int                  $bitrix24PartnerId,
+        int                   $bitrix24PartnerId,
         ?string               $site,
         ?PhoneNumber          $phoneNumber,
         ?string               $email,
@@ -368,7 +368,7 @@ abstract class Bitrix24PartnerInterfaceTest extends TestCase
         CarbonImmutable       $updatedAt,
         Bitrix24PartnerStatus $bitrix24PartnerStatus,
         string                $title,
-        ?int                  $bitrix24PartnerId,
+        int                   $bitrix24PartnerId,
         ?string               $site,
         ?PhoneNumber          $phoneNumber,
         ?string               $email,
@@ -393,7 +393,7 @@ abstract class Bitrix24PartnerInterfaceTest extends TestCase
         CarbonImmutable       $updatedAt,
         Bitrix24PartnerStatus $bitrix24PartnerStatus,
         string                $title,
-        ?int                  $bitrix24PartnerId,
+        int                   $bitrix24PartnerId,
         ?string               $site,
         ?PhoneNumber          $phoneNumber,
         ?string               $email,
@@ -424,7 +424,7 @@ abstract class Bitrix24PartnerInterfaceTest extends TestCase
         CarbonImmutable       $updatedAt,
         Bitrix24PartnerStatus $bitrix24PartnerStatus,
         string                $title,
-        ?int                  $bitrix24PartnerId,
+        int                   $bitrix24PartnerId,
         ?string               $site,
         ?PhoneNumber          $phoneNumber,
         ?string               $email,
@@ -446,7 +446,7 @@ abstract class Bitrix24PartnerInterfaceTest extends TestCase
         CarbonImmutable       $updatedAt,
         Bitrix24PartnerStatus $bitrix24PartnerStatus,
         string                $title,
-        ?int                  $bitrix24PartnerId,
+        int                   $bitrix24PartnerId,
         ?string               $site,
         ?PhoneNumber          $phoneNumber,
         ?string               $email,
@@ -473,7 +473,7 @@ abstract class Bitrix24PartnerInterfaceTest extends TestCase
         CarbonImmutable       $updatedAt,
         Bitrix24PartnerStatus $bitrix24PartnerStatus,
         string                $title,
-        ?int                  $bitrix24PartnerId,
+        int                   $bitrix24PartnerId,
         ?string               $site,
         ?PhoneNumber          $phoneNumber,
         ?string               $email,
@@ -495,7 +495,7 @@ abstract class Bitrix24PartnerInterfaceTest extends TestCase
         CarbonImmutable       $updatedAt,
         Bitrix24PartnerStatus $bitrix24PartnerStatus,
         string                $title,
-        ?int                  $bitrix24PartnerId,
+        int                   $bitrix24PartnerId,
         ?string               $site,
         ?PhoneNumber          $phoneNumber,
         ?string               $email,
@@ -527,7 +527,7 @@ abstract class Bitrix24PartnerInterfaceTest extends TestCase
         CarbonImmutable       $updatedAt,
         Bitrix24PartnerStatus $bitrix24PartnerStatus,
         string                $title,
-        ?int                  $bitrix24PartnerId,
+        int                   $bitrix24PartnerId,
         ?string               $site,
         ?PhoneNumber          $phoneNumber,
         ?string               $email,
@@ -552,7 +552,7 @@ abstract class Bitrix24PartnerInterfaceTest extends TestCase
         CarbonImmutable       $updatedAt,
         Bitrix24PartnerStatus $bitrix24PartnerStatus,
         string                $title,
-        ?int                  $bitrix24PartnerId,
+        int                   $bitrix24PartnerId,
         ?string               $site,
         ?PhoneNumber          $phoneNumber,
         ?string               $email,
@@ -567,37 +567,6 @@ abstract class Bitrix24PartnerInterfaceTest extends TestCase
 
     #[Test]
     #[DataProvider('bitrix24PartnerDataProvider')]
-    #[TestDox('test setBitrix24PartnerId')]
-    final public function testSetBitrix24PartnerId(
-        Uuid                  $uuid,
-        CarbonImmutable       $createdAt,
-        CarbonImmutable       $updatedAt,
-        Bitrix24PartnerStatus $bitrix24PartnerStatus,
-        string                $title,
-        ?int                  $bitrix24PartnerId,
-        ?string               $site,
-        ?PhoneNumber          $phoneNumber,
-        ?string               $email,
-        ?string               $openLineId,
-        ?string               $externalId,
-        string                $comment
-    ): void
-    {
-        $bitrix24Partner = $this->createBitrix24PartnerImplementation($uuid, $createdAt, $updatedAt, $bitrix24PartnerStatus, $title, $bitrix24PartnerId, $site, $phoneNumber, $email, $openLineId, $externalId);
-        $newBitrix24PartnerId = 123;
-        $bitrix24Partner->setBitrix24PartnerId($newBitrix24PartnerId);
-        $this->assertEquals($newBitrix24PartnerId, $bitrix24Partner->getBitrix24PartnerId());
-
-        $bitrix24Partner->setBitrix24PartnerId(null);
-        $this->assertNull($bitrix24Partner->getBitrix24PartnerId());
-
-        $this->expectException(InvalidArgumentException::class);
-        /** @phpstan-ignore-next-line */
-        $bitrix24Partner->setBitrix24PartnerId(0);
-    }
-
-    #[Test]
-    #[DataProvider('bitrix24PartnerDataProvider')]
     #[TestDox('test getOpenLineId')]
     final public function testGetOpenLineId(
         Uuid                  $uuid,
@@ -605,7 +574,7 @@ abstract class Bitrix24PartnerInterfaceTest extends TestCase
         CarbonImmutable       $updatedAt,
         Bitrix24PartnerStatus $bitrix24PartnerStatus,
         string                $title,
-        ?int                  $bitrix24PartnerId,
+        int                   $bitrix24PartnerId,
         ?string               $site,
         ?PhoneNumber          $phoneNumber,
         ?string               $email,
@@ -627,7 +596,7 @@ abstract class Bitrix24PartnerInterfaceTest extends TestCase
         CarbonImmutable       $updatedAt,
         Bitrix24PartnerStatus $bitrix24PartnerStatus,
         string                $title,
-        ?int                  $bitrix24PartnerId,
+        int                   $bitrix24PartnerId,
         ?string               $site,
         ?PhoneNumber          $phoneNumber,
         ?string               $email,

--- a/tests/Application/Contracts/Bitrix24Partners/Entity/Bitrix24PartnerInterfaceTest.php
+++ b/tests/Application/Contracts/Bitrix24Partners/Entity/Bitrix24PartnerInterfaceTest.php
@@ -189,6 +189,7 @@ abstract class Bitrix24PartnerInterfaceTest extends TestCase
     {
         $bitrix24Partner = $this->createBitrix24PartnerImplementation($uuid, $createdAt, $updatedAt, $bitrix24PartnerStatus, $title, $bitrix24PartnerId, $site, $phoneNumber, $email, $openLineId, $externalId);
         $this->expectException(InvalidArgumentException::class);
+        /** @phpstan-ignore-next-line */
         $bitrix24Partner->setExternalId('');
     }
 

--- a/tests/Unit/Application/Contracts/Bitrix24Partners/Entity/Bitrix24PartnerInterfaceReferenceImplementationTest.php
+++ b/tests/Unit/Application/Contracts/Bitrix24Partners/Entity/Bitrix24PartnerInterfaceReferenceImplementationTest.php
@@ -30,7 +30,7 @@ class Bitrix24PartnerInterfaceReferenceImplementationTest extends Bitrix24Partne
         CarbonImmutable       $updatedAt,
         Bitrix24PartnerStatus $bitrix24PartnerStatus,
         string                $title,
-        ?int                  $bitrix24PartnerId,
+        int                   $bitrix24PartnerId,
         ?string               $site,
         ?PhoneNumber          $phoneNumber,
         ?string               $email,

--- a/tests/Unit/Application/Contracts/Bitrix24Partners/Entity/Bitrix24PartnerReferenceEntityImplementation.php
+++ b/tests/Unit/Application/Contracts/Bitrix24Partners/Entity/Bitrix24PartnerReferenceEntityImplementation.php
@@ -48,7 +48,7 @@ final class Bitrix24PartnerReferenceEntityImplementation implements Bitrix24Part
         private CarbonImmutable          $updatedAt,
         private Bitrix24PartnerStatus    $bitrix24PartnerStatus,
         private string                   $title,
-        private ?int                     $bitrix24PartnerId,
+        private readonly int             $bitrix24PartnerId,
         private ?string                  $site,
         private ?PhoneNumber             $phoneNumber,
         private ?string                  $email,
@@ -56,6 +56,9 @@ final class Bitrix24PartnerReferenceEntityImplementation implements Bitrix24Part
         private ?string                  $externalId
     )
     {
+        if ($bitrix24PartnerId <= 0) {
+            throw new InvalidArgumentException(sprintf('bitrix24 partner id must be positive int, now «%s»', $bitrix24PartnerId));
+        }
     }
 
     public function emitEvents(): array
@@ -153,19 +156,9 @@ final class Bitrix24PartnerReferenceEntityImplementation implements Bitrix24Part
         $this->updatedAt = new CarbonImmutable();
     }
 
-    public function getBitrix24PartnerId(): ?int
+    public function getBitrix24PartnerId(): int
     {
         return $this->bitrix24PartnerId;
-    }
-
-    public function setBitrix24PartnerId(?int $bitrix24PartnerId): void
-    {
-        if ($bitrix24PartnerId !== null && $bitrix24PartnerId <= 0) {
-            throw new InvalidArgumentException(sprintf('bitrix24 partner id must be positive int, now «%s»', $bitrix24PartnerId));
-        }
-
-        $this->bitrix24PartnerId = $bitrix24PartnerId;
-        $this->updatedAt = new CarbonImmutable();
     }
 
     public function getOpenLineId(): ?string

--- a/tests/Unit/Application/Contracts/Bitrix24Partners/Repository/InMemoryBitrix24PartnerRepositoryImplementation.php
+++ b/tests/Unit/Application/Contracts/Bitrix24Partners/Repository/InMemoryBitrix24PartnerRepositoryImplementation.php
@@ -116,11 +116,6 @@ class InMemoryBitrix24PartnerRepositoryImplementation implements Bitrix24Partner
             'bitrix24PartnerId' => $bitrix24Partner->getBitrix24PartnerId()
         ]);
 
-        if ($bitrix24Partner->getBitrix24PartnerId() === null) {
-            $this->items[$bitrix24Partner->getId()->toRfc4122()] = $bitrix24Partner;
-            return;
-        }
-
         $existsPartner = $this->findByBitrix24PartnerId($bitrix24Partner->getBitrix24PartnerId());
         if ($existsPartner instanceof Bitrix24PartnerInterface && $existsPartner->getId() !== $bitrix24Partner->getId()) {
             throw new InvalidArgumentException(sprintf(


### PR DESCRIPTION
This commit implements the changes requested in issue #305 to make the Bitrix24 partner ID read-only. The partner ID can now only be set during entity construction and cannot be modified afterwards.

Changes:
- Removed setBitrix24PartnerId() method from Bitrix24PartnerInterface
- Changed getBitrix24PartnerId() return type from ?int to int (non-nullable)
- Updated Bitrix24PartnerReferenceEntityImplementation to use readonly int
- Added validation in constructor to ensure partnerId is positive
- Deprecated Bitrix24PartnerPartnerIdChangedEvent (will be removed in v2.0.0)
- Removed testSetBitrix24PartnerId test
- Updated all test method signatures to use int instead of ?int

Breaking Changes:
- partnerId is now required (not nullable) and must be set in constructor
- setBitrix24PartnerId() method has been removed
- getBitrix24PartnerId() now returns int instead of ?int

Fixes #305

| Q             | A                                                                                                                         |
|---------------|---------------------------------------------------------------------------------------------------------------------------|
| Bug fix?      | yes                                                                                                                    |
| New feature?  | no <!-- please update CHANGELOG.md file -->                                                                           |
| Deprecations? | yes <!-- please update CHANGELOG.md file -->                                                                           |
| Issues        | Fix #305  <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead --> |
| License       | **MIT**                                                                                                                       |

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally:
 - Always add tests and ensure they pass.
 - For new features, provide some code snippets to help understand usage.
-->