### PR TITLE
Fix MOVED_TIME to return CarbonImmutable instead of int

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,18 @@
     - Comprehensive unit tests with 13 test cases covering construction validation, version retrieval, and error handling
     - Uses standard `InvalidArgumentException` for all validation errors (no custom exceptions)
 
+### Fixed
+
+- Fixed `MOVED_TIME` field in `DealItemResult` and `LeadItemResult` to return `CarbonImmutable` instead of `int`,
+  [see details](https://github.com/bitrix24/b24phpsdk/issues/126):
+    - Moved `MOVED_TIME` from integer casting block to datetime casting block in `AbstractCrmItem::__get()`
+    - Field now correctly returns `CarbonImmutable` object matching the documented type
+    - Added comprehensive unit tests for `AbstractCrmItem` datetime field type casting with 8 test cases covering:
+        - `MOVED_TIME` returns `CarbonImmutable` for both snake_case and camelCase variants
+        - `DATE_CREATE`, `DATE_MODIFY`, `LAST_ACTIVITY_TIME` return `CarbonImmutable`
+        - `MOVED_BY_ID` correctly returns `int`
+        - Null handling for empty datetime and integer fields
+
 ## 1.8.0 - 2025.11.10
 
 ### Added

--- a/src/Services/CRM/Common/Result/AbstractCrmItem.php
+++ b/src/Services/CRM/Common/Result/AbstractCrmItem.php
@@ -37,6 +37,7 @@ use MoneyPHP\Percentage\Percentage;
 class AbstractCrmItem extends AbstractItem
 {
     private Currency $currency;
+
     private const CRM_USERFIELD_PREFIX = 'UF_CRM_';
 
     /**
@@ -98,6 +99,7 @@ class AbstractCrmItem extends AbstractItem
                 if ($this->data[$offset] !== '' && $this->data[$offset] !== null && $this->data[$offset] !== '0') {
                     return (int)$this->data[$offset];
                 }
+
                 return null;
             case 'EXPORT':
             case 'HAS_PHONE':
@@ -161,18 +163,21 @@ class AbstractCrmItem extends AbstractItem
                     $var = $this->data[$offset] * 100;
                     return new Money((string)$var, new Currency($this->currency->getCode()));
                 }
+
                 return null;
             case 'AMOUNT':
                 if ($this->data[$offset] !== '' && $this->data[$offset] !== null) {
                     $var = $this->data[$offset] * 100;
                     return new Money((string)$var, new Currency($this->data['CURRENCY']));
                 }
+
                 return null;
             case 'RESULT_CURRENCY_ID':
             case 'CURRENCY':
                 if ($this->data[$offset] !== '' && $this->data[$offset] !== null) {
                     return new Currency($this->data[$offset]);
                 }
+
                 return null;
             case 'PHONE':
                 if (!$this->isKeyExists($offset)) {
@@ -183,6 +188,7 @@ class AbstractCrmItem extends AbstractItem
                 foreach ($this->data[$offset] as $item) {
                     $items[] = new Phone($item);
                 }
+
                 return $items;
             case 'EMAIL':
                 if (!$this->isKeyExists($offset)) {
@@ -193,6 +199,7 @@ class AbstractCrmItem extends AbstractItem
                 foreach ($this->data[$offset] as $item) {
                     $items[] = new Email($item);
                 }
+
                 return $items;
             case 'WEB':
                 if (!$this->isKeyExists($offset)) {
@@ -203,6 +210,7 @@ class AbstractCrmItem extends AbstractItem
                 foreach ($this->data[$offset] as $item) {
                     $items[] = new Website($item);
                 }
+
                 return $items;
             case 'IM':
                 if (!$this->isKeyExists($offset)) {
@@ -213,6 +221,7 @@ class AbstractCrmItem extends AbstractItem
                 foreach ($this->data[$offset] as $item) {
                     $items[] = new InstantMessenger($item);
                 }
+
                 return $items;
             case 'currencyId':
             case 'accountCurrencyId':
@@ -222,6 +231,7 @@ class AbstractCrmItem extends AbstractItem
                 if ($this->data[$offset] !== null) {
                     return DealSemanticStage::from($this->data[$offset]);
                 }
+
                 return null;
             case 'DISCOUNT_TYPE_ID':
                 return DiscountType::from($this->data[$offset]);
@@ -250,7 +260,6 @@ class AbstractCrmItem extends AbstractItem
     /**
      * get userfield by field name
      *
-     * @param string $fieldName
      *
      * @return mixed|null
      * @throws UserfieldNotFoundException
@@ -260,6 +269,7 @@ class AbstractCrmItem extends AbstractItem
         if (!str_starts_with($fieldName, self::CRM_USERFIELD_PREFIX)) {
             $fieldName = self::CRM_USERFIELD_PREFIX . $fieldName;
         }
+
         if (!$this->isKeyExists($fieldName)) {
             throw new UserfieldNotFoundException(sprintf('crm userfield not found by field name %s', $fieldName));
         }
@@ -278,10 +288,12 @@ class AbstractCrmItem extends AbstractItem
         if ($entityTypeId <= 0) {
             throw new InvalidArgumentException('entityTypeId must be positive integer');
         }
+
         $fieldKey = sprintf('PARENT_ID_%d', $entityTypeId);
         if (!array_key_exists($fieldKey, $this->data)) {
             throw new InvalidArgumentException(sprintf('field «%s» for smart process with entityTypeId «%d» not found', $fieldKey, $entityTypeId));
         }
+
         if ($this->data[$fieldKey] === '' || $this->data[$fieldKey] === null) {
             return null;
         }
@@ -292,7 +304,7 @@ class AbstractCrmItem extends AbstractItem
     public function __construct(array $data, ?Currency $currency = null)
     {
         parent::__construct($data);
-        if ($currency !== null) {
+        if ($currency instanceof \Money\Currency) {
             $this->currency = $currency;
         }
     }

--- a/src/Services/CRM/Common/Result/AbstractCrmItem.php
+++ b/src/Services/CRM/Common/Result/AbstractCrmItem.php
@@ -59,7 +59,6 @@ class AbstractCrmItem extends AbstractItem
             case 'CREATED_BY_ID':
             case 'MODIFY_BY_ID':
             case 'MOVED_BY_ID':
-            case 'MOVED_TIME':
             case 'createdBy':
             case 'updatedBy':
             case 'movedBy':
@@ -138,6 +137,7 @@ class AbstractCrmItem extends AbstractItem
             case 'createdTime':
             case 'updatedTime':
             case 'movedTime':
+            case 'MOVED_TIME':
             case 'lastActivityTime':
             case 'LAST_ACTIVITY_TIME':
             case 'START_TIME':

--- a/tests/Unit/Services/CRM/Common/Result/AbstractCrmItemTest.php
+++ b/tests/Unit/Services/CRM/Common/Result/AbstractCrmItemTest.php
@@ -23,68 +23,68 @@ class AbstractCrmItemTest extends TestCase
     public function testMovedTimeReturnsCarbonImmutable(): void
     {
         $testDateTime = '2024-03-17T10:30:45+00:00';
-        $item = new TestCrmItem(['MOVED_TIME' => $testDateTime]);
+        $testCrmItem = new TestCrmItem(['MOVED_TIME' => $testDateTime]);
 
-        $this->assertInstanceOf(CarbonImmutable::class, $item->MOVED_TIME);
-        $this->assertEquals($testDateTime, $item->MOVED_TIME->format(DATE_ATOM));
+        $this->assertInstanceOf(CarbonImmutable::class, $testCrmItem->MOVED_TIME);
+        $this->assertEquals($testDateTime, $testCrmItem->MOVED_TIME->format(DATE_ATOM));
     }
 
     public function testMovedTimeReturnsNullWhenEmpty(): void
     {
-        $item = new TestCrmItem(['MOVED_TIME' => '']);
+        $testCrmItem = new TestCrmItem(['MOVED_TIME' => '']);
 
-        $this->assertNull($item->MOVED_TIME);
+        $this->assertNull($testCrmItem->MOVED_TIME);
     }
 
     public function testMovedTimeCamelCaseReturnsCarbonImmutable(): void
     {
         $testDateTime = '2024-03-17T10:30:45+00:00';
-        $item = new TestCrmItem(['movedTime' => $testDateTime]);
+        $testCrmItem = new TestCrmItem(['movedTime' => $testDateTime]);
 
-        $this->assertInstanceOf(CarbonImmutable::class, $item->movedTime);
-        $this->assertEquals($testDateTime, $item->movedTime->format(DATE_ATOM));
+        $this->assertInstanceOf(CarbonImmutable::class, $testCrmItem->movedTime);
+        $this->assertEquals($testDateTime, $testCrmItem->movedTime->format(DATE_ATOM));
     }
 
     public function testDateCreateReturnsCarbonImmutable(): void
     {
         $testDateTime = '2024-03-17T10:30:45+00:00';
-        $item = new TestCrmItem(['DATE_CREATE' => $testDateTime]);
+        $testCrmItem = new TestCrmItem(['DATE_CREATE' => $testDateTime]);
 
-        $this->assertInstanceOf(CarbonImmutable::class, $item->DATE_CREATE);
-        $this->assertEquals($testDateTime, $item->DATE_CREATE->format(DATE_ATOM));
+        $this->assertInstanceOf(CarbonImmutable::class, $testCrmItem->DATE_CREATE);
+        $this->assertEquals($testDateTime, $testCrmItem->DATE_CREATE->format(DATE_ATOM));
     }
 
     public function testDateModifyReturnsCarbonImmutable(): void
     {
         $testDateTime = '2024-03-17T10:30:45+00:00';
-        $item = new TestCrmItem(['DATE_MODIFY' => $testDateTime]);
+        $testCrmItem = new TestCrmItem(['DATE_MODIFY' => $testDateTime]);
 
-        $this->assertInstanceOf(CarbonImmutable::class, $item->DATE_MODIFY);
-        $this->assertEquals($testDateTime, $item->DATE_MODIFY->format(DATE_ATOM));
+        $this->assertInstanceOf(CarbonImmutable::class, $testCrmItem->DATE_MODIFY);
+        $this->assertEquals($testDateTime, $testCrmItem->DATE_MODIFY->format(DATE_ATOM));
     }
 
     public function testLastActivityTimeReturnsCarbonImmutable(): void
     {
         $testDateTime = '2024-03-17T10:30:45+00:00';
-        $item = new TestCrmItem(['LAST_ACTIVITY_TIME' => $testDateTime]);
+        $testCrmItem = new TestCrmItem(['LAST_ACTIVITY_TIME' => $testDateTime]);
 
-        $this->assertInstanceOf(CarbonImmutable::class, $item->LAST_ACTIVITY_TIME);
-        $this->assertEquals($testDateTime, $item->LAST_ACTIVITY_TIME->format(DATE_ATOM));
+        $this->assertInstanceOf(CarbonImmutable::class, $testCrmItem->LAST_ACTIVITY_TIME);
+        $this->assertEquals($testDateTime, $testCrmItem->LAST_ACTIVITY_TIME->format(DATE_ATOM));
     }
 
     public function testMovedByIdReturnsInt(): void
     {
-        $item = new TestCrmItem(['MOVED_BY_ID' => '123']);
+        $testCrmItem = new TestCrmItem(['MOVED_BY_ID' => '123']);
 
-        $this->assertIsInt($item->MOVED_BY_ID);
-        $this->assertEquals(123, $item->MOVED_BY_ID);
+        $this->assertIsInt($testCrmItem->MOVED_BY_ID);
+        $this->assertEquals(123, $testCrmItem->MOVED_BY_ID);
     }
 
     public function testMovedByIdReturnsNullWhenEmpty(): void
     {
-        $item = new TestCrmItem(['MOVED_BY_ID' => '']);
+        $testCrmItem = new TestCrmItem(['MOVED_BY_ID' => '']);
 
-        $this->assertNull($item->MOVED_BY_ID);
+        $this->assertNull($testCrmItem->MOVED_BY_ID);
     }
 }
 

--- a/tests/Unit/Services/CRM/Common/Result/AbstractCrmItemTest.php
+++ b/tests/Unit/Services/CRM/Common/Result/AbstractCrmItemTest.php
@@ -1,0 +1,101 @@
+<?php
+
+/**
+ * This file is part of the bitrix24-php-sdk package.
+ *
+ * © Maksim Mesilov <mesilov.maxim@gmail.com>
+ *
+ * For the full copyright and license information, please view the MIT-LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Bitrix24\SDK\Tests\Unit\Services\CRM\Common\Result;
+
+use Bitrix24\SDK\Services\CRM\Common\Result\AbstractCrmItem;
+use Carbon\CarbonImmutable;
+use PHPUnit\Framework\TestCase;
+
+#[\PHPUnit\Framework\Attributes\CoversClass(\Bitrix24\SDK\Services\CRM\Common\Result\AbstractCrmItem::class)]
+class AbstractCrmItemTest extends TestCase
+{
+    public function testMovedTimeReturnsCarbonImmutable(): void
+    {
+        $testDateTime = '2024-03-17T10:30:45+00:00';
+        $item = new TestCrmItem(['MOVED_TIME' => $testDateTime]);
+
+        $this->assertInstanceOf(CarbonImmutable::class, $item->MOVED_TIME);
+        $this->assertEquals($testDateTime, $item->MOVED_TIME->format(DATE_ATOM));
+    }
+
+    public function testMovedTimeReturnsNullWhenEmpty(): void
+    {
+        $item = new TestCrmItem(['MOVED_TIME' => '']);
+
+        $this->assertNull($item->MOVED_TIME);
+    }
+
+    public function testMovedTimeCamelCaseReturnsCarbonImmutable(): void
+    {
+        $testDateTime = '2024-03-17T10:30:45+00:00';
+        $item = new TestCrmItem(['movedTime' => $testDateTime]);
+
+        $this->assertInstanceOf(CarbonImmutable::class, $item->movedTime);
+        $this->assertEquals($testDateTime, $item->movedTime->format(DATE_ATOM));
+    }
+
+    public function testDateCreateReturnsCarbonImmutable(): void
+    {
+        $testDateTime = '2024-03-17T10:30:45+00:00';
+        $item = new TestCrmItem(['DATE_CREATE' => $testDateTime]);
+
+        $this->assertInstanceOf(CarbonImmutable::class, $item->DATE_CREATE);
+        $this->assertEquals($testDateTime, $item->DATE_CREATE->format(DATE_ATOM));
+    }
+
+    public function testDateModifyReturnsCarbonImmutable(): void
+    {
+        $testDateTime = '2024-03-17T10:30:45+00:00';
+        $item = new TestCrmItem(['DATE_MODIFY' => $testDateTime]);
+
+        $this->assertInstanceOf(CarbonImmutable::class, $item->DATE_MODIFY);
+        $this->assertEquals($testDateTime, $item->DATE_MODIFY->format(DATE_ATOM));
+    }
+
+    public function testLastActivityTimeReturnsCarbonImmutable(): void
+    {
+        $testDateTime = '2024-03-17T10:30:45+00:00';
+        $item = new TestCrmItem(['LAST_ACTIVITY_TIME' => $testDateTime]);
+
+        $this->assertInstanceOf(CarbonImmutable::class, $item->LAST_ACTIVITY_TIME);
+        $this->assertEquals($testDateTime, $item->LAST_ACTIVITY_TIME->format(DATE_ATOM));
+    }
+
+    public function testMovedByIdReturnsInt(): void
+    {
+        $item = new TestCrmItem(['MOVED_BY_ID' => '123']);
+
+        $this->assertIsInt($item->MOVED_BY_ID);
+        $this->assertEquals(123, $item->MOVED_BY_ID);
+    }
+
+    public function testMovedByIdReturnsNullWhenEmpty(): void
+    {
+        $item = new TestCrmItem(['MOVED_BY_ID' => '']);
+
+        $this->assertNull($item->MOVED_BY_ID);
+    }
+}
+
+/**
+ * @property-read CarbonImmutable|null $MOVED_TIME
+ * @property-read CarbonImmutable|null $movedTime
+ * @property-read CarbonImmutable|null $DATE_CREATE
+ * @property-read CarbonImmutable|null $DATE_MODIFY
+ * @property-read CarbonImmutable|null $LAST_ACTIVITY_TIME
+ * @property-read int|null $MOVED_BY_ID
+ */
+class TestCrmItem extends AbstractCrmItem
+{
+}


### PR DESCRIPTION
Fixes #126

MOVED_TIME field in DealItemResult and LeadItemResult was documented as CarbonImmutable but was actually returning int due to incorrect casting logic in AbstractCrmItem.

Changes:
- Moved MOVED_TIME from integer casting block to datetime casting block in AbstractCrmItem::__get()
- Added unit tests to verify MOVED_TIME returns CarbonImmutable
- Tests also cover other datetime fields to ensure consistency

The field now correctly returns CarbonImmutable, matching the API documentation and expected behavior.

| Q             | A                                                                                                                         |
|---------------|---------------------------------------------------------------------------------------------------------------------------|
| Bug fix?      | yes                                                                                                                    |
| New feature?  | no <!-- please update CHANGELOG.md file -->                                                                           |
| Deprecations? | no <!-- please update CHANGELOG.md file -->                                                                           |
| Issues        | Fix #126  <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead --> |
| License       | **MIT**                                                                                                                       |

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally:
 - Always add tests and ensure they pass.
 - For new features, provide some code snippets to help understand usage.
-->