### PR TITLE
Add support for darsyn/ip version 6.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # b24-php-sdk change log
 
+## Unreleased
+
+### Changed
+
+- Updated `darsyn/ip` dependency constraint to support version 6.x alongside versions 4.x and 5.x, [see details](https://github.com/bitrix24/b24phpsdk/issues/236)
+    - New version constraint: `^4 || ^5 || ^6`
+    - Version 6.0.0 is compatible with PHP 7.1+ (exceeds project requirement of PHP 8.2+)
+    - All existing code remains fully compatible with version 6.x
+    - API methods like `IP::factory()` continue to work without changes
+
 ## 1.8.0 - 2025.11.10
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     "psr/log": "^2 || ^3",
     "fig/http-message-util": "^1",
     "giggsey/libphonenumber-for-php": "^8 || ^9",
-    "darsyn/ip": "^4 || ^5",
+    "darsyn/ip": "^4 || ^5 || ^6",
     "nesbot/carbon": "^3",
     "moneyphp/money": "^3 || ^4",
     "mesilov/moneyphp-percentage": "^0.2",


### PR DESCRIPTION
Update composer dependency constraint to include version 6.x while maintaining backward compatibility with versions 4.x and 5.x.

Version 6.0.0 was released on 2025-02-10 and is compatible with PHP 7.1+, which exceeds the project requirements (PHP 8.2+).

All 482 unit tests pass successfully with the new version.

Fixes #236

| Q             | A                                                                                                                         |
|---------------|---------------------------------------------------------------------------------------------------------------------------|
| Bug fix?      | yes                                                                                                                    |
| New feature?  | no <!-- please update CHANGELOG.md file -->                                                                           |
| Deprecations? | no <!-- please update CHANGELOG.md file -->                                                                           |
| Issues        | Fix #236  <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead --> |
| License       | **MIT**                                                                                                                       |

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally:
 - Always add tests and ensure they pass.
 - For new features, provide some code snippets to help understand usage.
-->