### PR TITLE
Add markEmailAsVerified() call in testFindByEmailWithVerifiedEmail test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,86 @@
 # b24-php-sdk change log
 
+## 1.9.0 - 2025.12.01
+
+### Added
+
+- Added ApplicationSettings contracts for managing application configuration settings with support for multiple scopes (global, user-specific, department-specific):
+  - Entity interface `ApplicationSettingsItemInterface` with methods for managing settings lifecycle
+  - Repository interface `ApplicationSettingsItemRepositoryInterface` with CRUD operations and scope-based queries
+  - Enum `ApplicationSettingStatus` for tracking setting state (active/deleted)
+  - Events for tracking settings changes:
+    - `ApplicationSettingsItemCreatedEvent` - triggered when new setting is created
+    - `ApplicationSettingsItemChangedEvent` - triggered when setting value is updated (includes old/new values and change author)
+    - `ApplicationSettingsItemDeletedEvent` - triggered when setting is soft-deleted
+  - Exception `ApplicationSettingsItemNotFoundException` for handling missing settings
+  - Comprehensive abstract test classes for entity and repository contracts
+  - Documentation in `src/Application/Contracts/ApplicationSettings/Docs/ApplicationSettings.md`
+- Added `VersionedScope` container class for managing multiple Scope instances with version support:
+    - Readonly immutable container storing multiple `Scope` instances indexed by version number
+    - Versions must be unique integers starting from 1
+    - `getScope(int $version): Scope` method retrieves Scope by version number (throws `InvalidArgumentException` if version doesn't exist)
+    - `getVersions(): array` method returns sorted array of all available version numbers
+    - `hasVersion(int $version): bool` method checks if a specific version exists
+    - Comprehensive unit tests with 13 test cases covering construction validation, version retrieval, and error handling
+    - Uses standard `InvalidArgumentException` for all validation errors (no custom exceptions)
+- Added MCP (Model Context Protocol) server configuration for Bitrix24 API documentation [see details](https://github.com/bitrix24/b24phpsdk/issues/126):
+  - Added `.claude/mcp_settings.json` with Bitrix24 MCP server setup
+  - Enables direct access to Bitrix24 REST API documentation within Claude Code
+  - Provides tools for searching methods, viewing method details, and reading articles
+  - Improves developer experience when working with Bitrix24 API
+- Added specialized exceptions for OAuth token refresh errors, [see details](https://github.com/bitrix24/b24phpsdk/issues/284):
+  - `InvalidGrantException` - thrown when refresh token is invalid or expired (requires user re-authorization)
+  - `PortalDomainNotFoundException` - thrown when Bitrix24 portal domain is not found or inaccessible
+  - These exceptions allow developers to implement specific error handling logic based on the actual failure cause
+
+### Changed
+
+- Updated `darsyn/ip` dependency constraint to support version 6.x alongside versions 4.x and 5.x, [see details](https://github.com/bitrix24/b24phpsdk/issues/236)
+    - New version constraint: `^4 || ^5 || ^6`
+    - Version 6.0.0 is compatible with PHP 7.1+ (exceeds project requirement of PHP 8.2+)
+    - All existing code remains fully compatible with version 6.x
+    - API methods like `IP::factory()` continue to work without changes
+
+### Fixed
+
+- Fixed `MOVED_TIME` field in `DealItemResult` and `LeadItemResult` to return `CarbonImmutable` instead of `int`,
+  [see details](https://github.com/bitrix24/b24phpsdk/issues/126):
+    - Moved `MOVED_TIME` from integer casting block to datetime casting block in `AbstractCrmItem::__get()`
+    - Field now correctly returns `CarbonImmutable` object matching the documented type
+    - Added comprehensive unit tests for `AbstractCrmItem` datetime field type casting with 8 test cases covering:
+        - `MOVED_TIME` returns `CarbonImmutable` for both snake_case and camelCase variants
+        - `DATE_CREATE`, `DATE_MODIFY`, `LAST_ACTIVITY_TIME` return `CarbonImmutable`
+        - `MOVED_BY_ID` correctly returns `int`
+        - Null handling for empty datetime and integer fields
+- Fixed invalid type casting hints in `FlowItemResult`,
+  [see details](https://github.com/bitrix24/b24phpsdk/issues/275):
+    - Added missing `@property-read bool $active` annotation
+    - Corrected nullable type annotations to match Bitrix24 API documentation for `task.flow.Flow.get` method:
+        - `responsibleList`: changed from `array|null` to `array` (required field)
+        - `demo`: changed from `bool|null` to `bool` (required field)
+        - `responsibleCanChangeDeadline`: changed from `bool|null` to `bool` (required field)
+        - `matchWorkTime`: changed from `bool|null` to `bool` (required field)
+        - `taskControl`: changed from `bool|null` to `bool` (required field)
+        - `notifyAtHalfTime`: changed from `bool|null` to `bool` (required field)
+        - `taskCreators`: changed from `array|null` to `array` (required field)
+        - `team`: changed from `array|null` to `array` (required field)
+        - `trialFeatureEnabled`: changed from `bool|null` to `bool` (required field)
+    - Preserved correct nullable types for notification thresholds: `notifyOnQueueOverflow`, `notifyOnTasksInProgressOverflow`, `notifyWhenEfficiencyDecreases` (int|null)
+- Improved error handling during OAuth token refresh in `ApiClient::getNewAuthToken()`, [see details](https://github.com/bitrix24/b24phpsdk/issues/284):
+    - Replaced generic error messages with specific exception types based on HTTP status codes and OAuth error codes
+    - Added detailed error handling for different scenarios:
+        - HTTP 400 with `invalid_grant` → throws `InvalidGrantException` (user re-authorization required)
+        - HTTP 401 with `invalid_client` → throws `WrongClientException` (configuration issue)
+        - HTTP 404 → throws `PortalDomainNotFoundException` (portal not found)
+        - HTTP 5xx → throws `TransportException` with retry suggestion (server errors)
+    - Enhanced error messages include both OAuth error code and description for better diagnostics
+    - Developers can now distinguish between different failure causes and implement specific recovery logic
+    - Added comprehensive unit tests covering all error scenarios
+- Fixed `testFindByEmailWithVerifiedEmail` test in `ContactPersonRepositoryInterfaceTest` to properly mark email as verified,
+  [see details](https://github.com/bitrix24/b24phpsdk/issues/316):
+    - Added `markEmailAsVerified()` call for the first contact person after save and before flush
+    - Ensures the test correctly validates the `findByEmail` method with `onlyVerified=true` flag
+
 ## 1.8.0 - 2025.11.10
 
 ### Added

--- a/tests/Application/Contracts/ContactPersons/Repository/ContactPersonRepositoryInterfaceTest.php
+++ b/tests/Application/Contracts/ContactPersons/Repository/ContactPersonRepositoryInterfaceTest.php
@@ -359,10 +359,11 @@ abstract class ContactPersonRepositoryInterfaceTest extends TestCase
             $contactPerson = $this->createContactPersonImplementation($uuid, $createdAt, $updatedAt, $contactPersonStatus, $name, $surname, $patronymic, $email, $emailVerifiedAt, $comment, $mobilePhone, $mobilePhoneVerifiedAt, $externalId, $bitrix24UserId, $bitrix24PartnerId, $userAgent, $userAgentReferer, $userAgentIp);
 
             $contactPersonRepository->save($contactPerson);
-            $flusher->flush();
             if (!$expectedContactPerson instanceof ContactPersonInterface) {
+                $contactPerson->markEmailAsVerified();
                 $expectedContactPerson = $contactPerson;
             }
+            $flusher->flush();
         }
 
         $result = $contactPersonRepository->findByEmail($expectedContactPerson->getEmail(), null, true);


### PR DESCRIPTION
The test now properly marks the first contact person's email as verified before flushing, ensuring the findByEmail method correctly filters by verified emails in the database.

Fixes #316

| Q             | A                                                                                                                         |
|---------------|---------------------------------------------------------------------------------------------------------------------------|
| Bug fix?      | yes                                                                                                                    |
| New feature?  | no <!-- please update CHANGELOG.md file -->                                                                           |
| Deprecations? | no <!-- please update CHANGELOG.md file -->                                                                           |
| Issues        | Fix #316  <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead --> |
| License       | **MIT**                                                                                                                       |

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally:
 - Always add tests and ensure they pass.
 - For new features, provide some code snippets to help understand usage.
-->