### PR TITLE
Fix issue 314 in B24 PHP SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,10 @@
   [see details](https://github.com/bitrix24/b24phpsdk/issues/316):
     - Added `markEmailAsVerified()` call for the first contact person after save and before flush
     - Ensures the test correctly validates the `findByEmail` method with `onlyVerified=true` flag
+- Fixed `testDelete` test in `ContactPersonRepositoryInterfaceTest` to call `flush()` after delete,
+  [see details](https://github.com/bitrix24/b24phpsdk/issues/314):
+    - Added `$flusher->flush()` call after `$contactPersonRepository->delete()` to persist changes
+    - Ensures the test accurately reflects actual system behavior by persisting deletion before verifying the exception
 
 ## 1.8.0 - 2025.11.10
 

--- a/tests/Application/Contracts/ContactPersons/Repository/ContactPersonRepositoryInterfaceTest.php
+++ b/tests/Application/Contracts/ContactPersons/Repository/ContactPersonRepositoryInterfaceTest.php
@@ -135,6 +135,7 @@ abstract class ContactPersonRepositoryInterfaceTest extends TestCase
         $contactPerson->markAsDeleted('soft delete account');
 
         $contactPersonRepository->delete($contactPerson->getId());
+        $flusher->flush();
 
         $this->expectException(ContactPersonNotFoundException::class);
         $contactPersonRepository->getById($contactPerson->getId());


### PR DESCRIPTION
…elete

This ensures the test accurately reflects actual system behavior by persisting the deletion to the database before verifying the exception.

Fixes #314

| Q             | A                                                                                                                         |
|---------------|---------------------------------------------------------------------------------------------------------------------------|
| Bug fix?      | yes                                                                                                                    |
| New feature?  | no <!-- please update CHANGELOG.md file -->                                                                           |
| Deprecations? | no <!-- please update CHANGELOG.md file -->                                                                           |
| Issues        | Fix #314  <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead --> |
| License       | **MIT**                                                                                                                       |

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally:
 - Always add tests and ensure they pass.
 - For new features, provide some code snippets to help understand usage.
-->