### PR TITLE
Fix testFindByEmailWithVerifiedPhone to mark phone as verified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,5 @@
 # b24-php-sdk change log
 
-## Unreleased
-
-### Fixed
-
-- Fixed `testFindByEmailWithVerifiedPhone` test in `ContactPersonRepositoryInterfaceTest` to properly mark phone as verified,
-  [see details](https://github.com/bitrix24/b24phpsdk/issues/315):
-    - Added `markMobilePhoneAsVerified()` call for the first contact person after save and before flush
-    - Ensures the test correctly validates the `findByPhone` method with `onlyVerified=true` flag
-
 ## 1.9.0 - 2025.12.01
 
 ### Added
@@ -89,6 +80,10 @@
   [see details](https://github.com/bitrix24/b24phpsdk/issues/316):
     - Added `markEmailAsVerified()` call for the first contact person after save and before flush
     - Ensures the test correctly validates the `findByEmail` method with `onlyVerified=true` flag
+- Fixed `testFindByEmailWithVerifiedPhone` test in `ContactPersonRepositoryInterfaceTest` to properly mark phone as verified,
+  [see details](https://github.com/bitrix24/b24phpsdk/issues/315):
+    - Added `markMobilePhoneAsVerified()` call for the first contact person after save and before flush
+    - Ensures the test correctly validates the `findByPhone` method with `onlyVerified=true` flag
 - Fixed `testDelete` test in `ContactPersonRepositoryInterfaceTest` to call `flush()` after delete,
   [see details](https://github.com/bitrix24/b24phpsdk/issues/314):
     - Added `$flusher->flush()` call after `$contactPersonRepository->delete()` to persist changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # b24-php-sdk change log
 
+## Unreleased
+
+### Fixed
+
+- Fixed `testFindByEmailWithVerifiedPhone` test in `ContactPersonRepositoryInterfaceTest` to properly mark phone as verified,
+  [see details](https://github.com/bitrix24/b24phpsdk/issues/315):
+    - Added `markMobilePhoneAsVerified()` call for the first contact person after save and before flush
+    - Ensures the test correctly validates the `findByPhone` method with `onlyVerified=true` flag
+
 ## 1.9.0 - 2025.12.01
 
 ### Added

--- a/tests/Application/Contracts/ContactPersons/Repository/ContactPersonRepositoryInterfaceTest.php
+++ b/tests/Application/Contracts/ContactPersons/Repository/ContactPersonRepositoryInterfaceTest.php
@@ -385,11 +385,13 @@ abstract class ContactPersonRepositoryInterfaceTest extends TestCase
         foreach ($items as $item) {
             [$uuid, $createdAt, $updatedAt, $contactPersonStatus, $name, $surname, $patronymic, $email, $emailVerifiedAt, $comment, $phoneNumber, $mobilePhoneVerifiedAt, $externalId, $bitrix24UserId, $bitrix24PartnerId, $userAgent, $userAgentReferer, $userAgentIp] = $item;
             $contactPerson = $this->createContactPersonImplementation($uuid, $createdAt, $updatedAt, $contactPersonStatus, $name, $surname, $patronymic, $email, $emailVerifiedAt, $comment, $phoneNumber, $mobilePhoneVerifiedAt, $externalId, $bitrix24UserId, $bitrix24PartnerId, $userAgent, $userAgentReferer, $userAgentIp);
+
             $contactPersonRepository->save($contactPerson);
-            $flusher->flush();
             if (!$expectedContactPerson instanceof ContactPersonInterface) {
+                $contactPerson->markMobilePhoneAsVerified();
                 $expectedContactPerson = $contactPerson;
             }
+            $flusher->flush();
         }
 
         $result = $contactPersonRepository->findByPhone($expectedContactPerson->getMobilePhone(), null, true);


### PR DESCRIPTION
Add markMobilePhoneAsVerified() call for the first contact person after save and before flush, ensuring the test correctly validates the findByPhone method with onlyVerified=true flag.

Fixes #315

| Q             | A                                                                                                                         |
|---------------|---------------------------------------------------------------------------------------------------------------------------|
| Bug fix?      | yes                                                                                                                    |
| New feature?  | no <!-- please update CHANGELOG.md file -->                                                                           |
| Deprecations? | no <!-- please update CHANGELOG.md file -->                                                                           |
| Issues        | Fix #315  <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead --> |
| License       | **MIT**                                                                                                                       |

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally:
 - Always add tests and ensure they pass.
 - For new features, provide some code snippets to help understand usage.
-->