### PR TITLE
Add isPartner() method to ContactPersonInterface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,11 @@
     - `addUser` adds users to group without invitation process
     - `deleteUser` removes users from group
     - `setOwner` changes group owner
+- Added `isPartner(): bool` method to `ContactPersonInterface` to check if the contact person is a partner employee,
+  [see details](https://github.com/bitrix24/b24phpsdk/issues/345):
+    - Returns `true` if the contact person has a Bitrix24 partner ID set
+    - Returns `false` if no partner ID is associated with the contact person
+    - Provides a convenience method instead of checking `getBitrix24PartnerId() !== null`
 
 ### Changed
 

--- a/src/Application/Contracts/ContactPersons/Entity/ContactPersonInterface.php
+++ b/src/Application/Contracts/ContactPersons/Entity/ContactPersonInterface.php
@@ -143,5 +143,10 @@ interface ContactPersonInterface
      */
     public function setBitrix24PartnerId(?Uuid $uuid): void;
 
+    /**
+     * @return bool true if contact person is a partner employee (has bitrix24 partner id set)
+     */
+    public function isPartner(): bool;
+
     public function getUserAgentInfo(): UserAgentInfo;
 }

--- a/tests/Application/Contracts/ContactPersons/Entity/ContactPersonInterfaceTest.php
+++ b/tests/Application/Contracts/ContactPersons/Entity/ContactPersonInterfaceTest.php
@@ -895,6 +895,44 @@ abstract class ContactPersonInterfaceTest extends TestCase
 
     #[Test]
     #[DataProvider('contactPersonDataProvider')]
+    #[TestDox('test isPartner method')]
+    final public function testIsPartner(
+        Uuid                $uuid,
+        CarbonImmutable     $createdAt,
+        CarbonImmutable     $updatedAt,
+        ContactPersonStatus $contactPersonStatus,
+        string              $name,
+        ?string             $surname,
+        ?string             $patronymic,
+        ?string             $email,
+        ?CarbonImmutable    $emailVerifiedAt,
+        ?string             $comment,
+        ?PhoneNumber        $phoneNumber,
+        ?CarbonImmutable    $mobilePhoneVerifiedAt,
+        ?string             $externalId,
+        ?int                $bitrix24UserId,
+        ?Uuid               $bitrix24PartnerUuid,
+        ?string             $userAgent,
+        ?string             $userAgentReferer,
+        ?IP                 $userAgentIp
+    ): void
+    {
+        // Test with no partner id
+        $contactPerson = $this->createContactPersonImplementation($uuid, $createdAt, $updatedAt, $contactPersonStatus, $name, $surname, $patronymic, $email, $emailVerifiedAt, $comment, $phoneNumber, $mobilePhoneVerifiedAt, $externalId, $bitrix24UserId, null, $userAgent, $userAgentReferer, $userAgentIp);
+        $this->assertFalse($contactPerson->isPartner());
+
+        // Test with partner id set
+        $partnerUuid = Uuid::v7();
+        $contactPerson->setBitrix24PartnerId($partnerUuid);
+        $this->assertTrue($contactPerson->isPartner());
+
+        // Test removing partner id
+        $contactPerson->setBitrix24PartnerId(null);
+        $this->assertFalse($contactPerson->isPartner());
+    }
+
+    #[Test]
+    #[DataProvider('contactPersonDataProvider')]
     #[TestDox('test getUserAgentInfo method')]
     final public function testGetUserAgentInfo(
         Uuid                $uuid,

--- a/tests/Unit/Application/Contracts/ContactPersons/Entity/ContactPersonReferenceEntityImplementation.php
+++ b/tests/Unit/Application/Contracts/ContactPersons/Entity/ContactPersonReferenceEntityImplementation.php
@@ -238,6 +238,12 @@ final class ContactPersonReferenceEntityImplementation implements ContactPersonI
     }
 
     #[\Override]
+    public function isPartner(): bool
+    {
+        return $this->bitrix24PartnerUuid instanceof Uuid;
+    }
+
+    #[\Override]
     public function getUserAgentInfo(): UserAgentInfo
     {
         return new UserAgentInfo(


### PR DESCRIPTION
Adds a convenience method to check if a contact person is a partner employee by verifying if they have a Bitrix24 partner ID set.

Closes #345

| Q             | A                                                                                                                         |
|---------------|---------------------------------------------------------------------------------------------------------------------------|
| Bug fix?      | no                                                                                                                    |
| New feature?  | yes <!-- please update CHANGELOG.md file -->                                                                           |
| Deprecations? | no <!-- please update CHANGELOG.md file -->                                                                           |
| Issues        | Fix #345  <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead --> |
| License       | **MIT**                                                                                                                       |

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally:
 - Always add tests and ensure they pass.
 - For new features, provide some code snippets to help understand usage.
-->