### PR TITLE
Add `ChatMessageField` service for `tasks.task.chat.message.field.*`

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,5 +2,24 @@
   "enabledPlugins": {
     "context7@claude-plugins-official": true,
     "learning-output-style@claude-plugins-official": true
+  },
+  "enabledMcpjsonServers": ["github"],
+  "permissions": {
+    "allow": [
+      "mcp__github__get_issue",
+      "mcp__github__get_pull_request",
+      "mcp__github__get_pull_request_comments",
+      "mcp__github__get_pull_request_files",
+      "mcp__github__get_pull_request_reviews",
+      "mcp__github__get_pull_request_status",
+      "mcp__github__get_file_contents",
+      "mcp__github__list_commits",
+      "mcp__github__list_issues",
+      "mcp__github__list_pull_requests",
+      "mcp__github__search_code",
+      "mcp__github__search_issues",
+      "mcp__github__search_repositories",
+      "mcp__github__search_users"
+    ]
   }
 }

--- a/.claude/skills/b24phpsdk-maintainer/SKILL.md
+++ b/.claude/skills/b24phpsdk-maintainer/SKILL.md
@@ -1,0 +1,268 @@
+---
+name: b24phpsdk-maintainer
+description: |
+  Use this skill whenever working with GitHub issues in the bitrix24/b24phpsdk repository:
+  creating new issues, reading existing ones, planning implementation from an issue,
+  or referencing an issue in commits, branches, or CHANGELOG.
+  IMPORTANT: this skill MUST be invoked before doing any issue-related work.
+user-invocable: true
+allowed-tools: mcp__github__get_issue, mcp__github__list_issues, mcp__github__create_issue, mcp__github__add_issue_comment, mcp__github__search_issues
+---
+
+# b24phpsdk Maintainer
+
+Repository: **bitrix24/b24phpsdk** (`owner: bitrix24`, `repo: b24phpsdk`)
+
+---
+
+## Working with an existing issue
+
+When given an issue number, always load it first via `mcp__github__get_issue`:
+
+```
+owner: bitrix24
+repo:  b24phpsdk
+issue_number: <N>
+```
+
+Read the title, body, and labels — they define the scope and context of the work.
+
+---
+
+## Creating a new issue
+
+Before creating, search via `mcp__github__search_issues` to make sure a similar issue does not already exist.
+
+### Issue body structure
+
+```markdown
+## Problem
+
+<Clear description of the problem or missing functionality>
+
+## Proposed solution
+
+<Description of the proposed solution>
+
+## Acceptance criteria
+
+- [ ] <criterion 1>
+- [ ] <criterion 2>
+- [ ] <criterion 3>
+```
+
+### Title rules
+
+- New functionality: `Add <feature description>`
+- Bug fix: `Fix <what is broken>`
+- Refactoring: `Refactor <what and why>`
+- Maximum 72 characters
+
+### Labels
+
+| Label | When to use |
+|---|---|
+| `enhancement` | new functionality |
+| `bug` | bug fix |
+| `documentation` | documentation only |
+| `refactoring` | internal changes without API changes |
+
+---
+
+## Project conventions when implementing an issue
+
+### Branch naming
+
+```
+feature/<issue-number>-<short-slug>   # new functionality
+bugfix/<issue-number>-<short-slug>    # bug fix
+```
+
+Example: `feature/397-add-task-chat-fields`
+
+### CHANGELOG.md references
+
+All entries under `## X.Y.Z Unreleased` → `### Added / Fixed / Changed` must end with an issue link:
+
+```markdown
+- Added something useful ([#NNN](https://github.com/bitrix24/b24phpsdk/issues/NNN))
+```
+
+### Test file structure
+
+When adding a new service for an issue, the following files are mandatory:
+- `tests/Unit/Services/<Scope>/Service/<Name>Test.php` — unit test for the service
+- `tests/Integration/Services/<Scope>/Service/<Name>Test.php` — integration test
+- `tests/Integration/Services/<Scope>/Result/<Name>ItemResultTest.php` — result item test (see below)
+- Add a suite to `phpunit.xml.dist` and a make target to `Makefile`
+
+See also: `docs/architecture.md`, `docs/testing.md`
+
+---
+
+### Mandatory integration test for every *ItemResult
+
+**Rule**: every `*ItemResult.php` file that contains `@property-read` PHPDoc annotations
+MUST have a corresponding integration test at
+`tests/Integration/Services/<Scope>/Result/<Name>ItemResultTest.php`.
+
+The test must contain exactly two methods:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Bitrix24\SDK\Tests\Integration\Services\<Scope>\Result;
+
+use Bitrix24\SDK\Services\<Scope>\Result\<Name>ItemResult;
+use Bitrix24\SDK\Services\<Scope>\Service\<ServiceName>;
+use Bitrix24\SDK\Tests\CustomAssertions\CustomBitrix24Assertions;
+use Bitrix24\SDK\Tests\Integration\Factory;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\TestDox;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(<Name>ItemResult::class)]
+class <Name>ItemResultTest extends TestCase
+{
+    use CustomBitrix24Assertions;
+
+    private <ServiceName> $<serviceNameCamel>;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        $this-><serviceNameCamel> = Factory::getServiceBuilder()->get<Scope>Scope()-><serviceAccessor>();
+    }
+
+    #[Test]
+    #[TestDox('all fields in <Name>ItemResult are annotated in phpdoc and match with raw api response')]
+    public function testAllFieldsAreAnnotated(): void
+    {
+        // fetch a raw single item array from the real API response
+        $rawItem = $this-><serviceNameCamel>-><fetchMethod>()->getCoreResponse()
+            ->getResponseData()->getResult()['<resultKey>'];
+
+        $this->assertBitrix24AllResultItemFieldsAnnotated(
+            array_keys($rawItem),
+            <Name>ItemResult::class
+        );
+    }
+
+    #[Test]
+    #[TestDox('all fields in <Name>ItemResult have valid type casting in magic getters')]
+    public function testAllFieldsHasValidTypeCastingInMagicGetters(): void
+    {
+        $<nameItemResult> = $this-><serviceNameCamel>-><fetchMethod>()-><itemAccessor>();
+        $this->assertBitrix24ResultItemFieldsTypeCastMatchAnnotations(
+            $<nameItemResult>,
+            <Name>ItemResult::class
+        );
+    }
+}
+```
+
+**Template notes:**
+- `assertBitrix24AllResultItemFieldsAnnotated` — verifies that every key from the raw API response is covered by a `@property-read` annotation in the result item class
+- `assertBitrix24ResultItemFieldsTypeCastMatchAnnotations` — verifies that every magic getter returns a value whose PHP type matches the PHPDoc annotation (uses Typhoon Reflection internally)
+- Both methods live in the trait `Bitrix24\SDK\Tests\CustomAssertions\CustomBitrix24Assertions`
+- `#[CoversClass]` must point to `*ItemResult`, not to the service class
+
+**Live example**: `tests/Integration/Services/Task/ChatMessageField/Result/ChatMessageFieldItemResultTest.php`
+
+---
+
+## Task folder and implementation plan
+
+**Rule**: before writing any code, create a dedicated folder and a plan file for the issue.
+
+### 1. Create the task folder
+
+```
+.tasks/<issue-number>/
+```
+
+Example: `.tasks/397/`
+
+### 2. Write the plan
+
+Create `.tasks/<issue-number>/plan.md` **before starting implementation**.
+Think through the full scope of the issue and write the plan first — only start coding once the plan is agreed upon.
+
+#### Plan file structure
+
+```markdown
+# Plan: <issue title> (issue #NNN)
+
+## Context
+
+<Background: what the issue is about, relevant API details, how it fits
+into the existing SDK structure, any constraints or decisions made upfront>
+
+---
+
+## Files to Create
+
+### 1. `src/...`
+
+<Full class skeleton with namespace, imports, and key method signatures>
+
+### 2. `tests/Unit/...`
+
+<Test class skeleton>
+
+### 3. `tests/Integration/...`
+
+<Integration test class skeleton>
+
+---
+
+## Files to Modify
+
+### 1. `src/Services/ServiceBuilder.php` (or scope builder)
+
+<Exact method to add, line reference if known>
+
+### 2. `phpunit.xml.dist`
+
+<Exact XML block to add>
+
+### 3. `Makefile`
+
+<Exact make target to add>
+
+---
+
+## Deptrac compliance
+
+<Confirm which layers the new code depends on and that no new violations are introduced>
+
+---
+
+## Verification
+
+\`\`\`bash
+make test-unit
+make test-integration-<scope>
+make lint-phpstan
+make lint-deptrac
+\`\`\`
+```
+
+### 3. Work from the plan
+
+Execute the plan step by step. Do not start a new step until the previous one is complete.
+Update the plan file if scope changes during implementation.
+
+---
+
+## Loading issue details at the start of work
+
+If the user mentions an issue number without explicitly calling `/b24phpsdk-maintainer`, still execute these steps:
+
+1. Load the issue via `mcp__github__get_issue`
+2. Output a short summary: what needs to be done
+3. Create `.tasks/<issue-number>/` and write `plan.md`
+4. Propose the plan for review before starting implementation

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "github": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-github"],
+      "env": {
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "$GITHUB_PERSONAL_ACCESS_TOKEN"
+      }
+    }
+  }
+}

--- a/.tasks/397/plan.md
+++ b/.tasks/397/plan.md
@@ -1,0 +1,326 @@
+# Plan: Add tasks.task.chat.message.field.* support (issue #397)
+
+## Context
+
+Bitrix24 REST API v3 exposes two methods for retrieving field descriptors of chat messages in tasks:
+- `tasks.task.chat.message.field.get` — metadata for one field by code (`name` param, returns `result.item`)
+- `tasks.task.chat.message.field.list` — all available field descriptors (returns `result.items`)
+
+The SDK already has a `TaskChat` service for `tasks.task.chat.message.send`. The new methods are metadata
+accessors for the **chat message field** domain object — a distinct concept that warrants a dedicated
+sub-namespace, consistent with `Commentitem/`, `Elapseditem/`, `Checklistitem/`, etc.
+
+**Real field properties** (from API docs, both methods):
+`name`, `type`, `title`, `description`, `validationRules`, `requiredGroups`,
+`filterable`, `sortable`, `editable`, `multiple`, `elementType`
+
+---
+
+## Files to Create
+
+### 1. `src/Services/Task/Chatmessagefield/Result/ChatmessagefieldItemResult.php`
+
+```php
+namespace Bitrix24\SDK\Services\Task\Chatmessagefield\Result;
+use Bitrix24\SDK\Core\Result\AbstractItem;
+
+/**
+ * @property-read string      $name
+ * @property-read string      $type
+ * @property-read string      $title
+ * @property-read string|null $description
+ * @property-read array|null  $validationRules
+ * @property-read array|null  $requiredGroups
+ * @property-read bool        $filterable
+ * @property-read bool        $sortable
+ * @property-read bool        $editable
+ * @property-read bool        $multiple
+ * @property-read string|null $elementType
+ */
+class ChatmessagefieldItemResult extends AbstractItem {}
+```
+
+### 2. `src/Services/Task/Chatmessagefield/Result/ChatmessagefieldResult.php`
+
+API returns `result: { item: {...} }` — key `item` must be used (same as `EventLogResult`).
+
+```php
+namespace Bitrix24\SDK\Services\Task\Chatmessagefield\Result;
+use Bitrix24\SDK\Core\Exceptions\BaseException;
+use Bitrix24\SDK\Core\Result\AbstractResult;
+
+class ChatmessagefieldResult extends AbstractResult
+{
+    /** @throws BaseException */
+    public function chatmessagefield(): ChatmessagefieldItemResult
+    {
+        return new ChatmessagefieldItemResult(
+            $this->getCoreResponse()->getResponseData()->getResult()['item']
+        );
+    }
+}
+```
+
+### 3. `src/Services/Task/Chatmessagefield/Result/ChatmessagefieldsResult.php`
+
+API returns `result: { items: [...] }` — key `items` must be used (same as `EventLogsResult`).
+
+```php
+namespace Bitrix24\SDK\Services\Task\Chatmessagefield\Result;
+use Bitrix24\SDK\Core\Exceptions\BaseException;
+use Bitrix24\SDK\Core\Result\AbstractResult;
+
+class ChatmessagefieldsResult extends AbstractResult
+{
+    /**
+     * @return ChatmessagefieldItemResult[]
+     * @throws BaseException
+     */
+    public function getChatmessagefields(): array
+    {
+        $items = [];
+        foreach ($this->getCoreResponse()->getResponseData()->getResult()['items'] as $item) {
+            $items[] = new ChatmessagefieldItemResult($item);
+        }
+        return $items;
+    }
+}
+```
+
+### 4. `src/Services/Task/Chatmessagefield/Service/Chatmessagefield.php`
+
+- `get()`: param is `name` (string, non-empty); validate with `guardNonEmptyString()`; optional `select`
+- `list()`: no required params; optional `select`
+
+```php
+namespace Bitrix24\SDK\Services\Task\Chatmessagefield\Service;
+
+use Bitrix24\SDK\Attributes\{ApiEndpointMetadata, ApiServiceMetadata};
+use Bitrix24\SDK\Core\Contracts\ApiVersion;
+use Bitrix24\SDK\Core\Credentials\Scope;
+use Bitrix24\SDK\Core\Exceptions\{BaseException, TransportException};
+use Bitrix24\SDK\Services\AbstractService;
+use Bitrix24\SDK\Services\Task\Chatmessagefield\Result\{ChatmessagefieldResult, ChatmessagefieldsResult};
+
+#[ApiServiceMetadata(new Scope(['task']))]
+class Chatmessagefield extends AbstractService
+{
+    /**
+     * Get metadata for a single task chat message field by field code.
+     *
+     * @link https://apidocs.bitrix24.ru/api-reference/rest-v3/tasks/tasks-task-chat-message-field-get.html
+     *
+     * @param non-empty-string $name   Field code, e.g. 'taskId'
+     * @param string[]         $select Fields to return. Available: name, type, title, description,
+     *                                 validationRules, requiredGroups, filterable, sortable,
+     *                                 editable, multiple, elementType
+     *
+     * @throws BaseException
+     * @throws TransportException
+     */
+    #[ApiEndpointMetadata(
+        'tasks.task.chat.message.field.get',
+        'https://apidocs.bitrix24.ru/api-reference/rest-v3/tasks/tasks-task-chat-message-field-get.html',
+        'Get metadata for a single task chat message field by field code',
+        ApiVersion::v3
+    )]
+    public function get(string $name, array $select = []): ChatmessagefieldResult
+    {
+        $this->guardNonEmptyString($name, 'field name must not be empty');
+
+        $params = ['name' => $name];
+        if ($select !== []) {
+            $params['select'] = $select;
+        }
+
+        return new ChatmessagefieldResult(
+            $this->core->call('tasks.task.chat.message.field.get', $params, ApiVersion::v3)
+        );
+    }
+
+    /**
+     * Get list of all available task chat message field descriptors.
+     *
+     * @link https://apidocs.bitrix24.ru/api-reference/rest-v3/tasks/tasks-task-chat-message-field-list.html
+     *
+     * @param string[] $select Fields to return. Available: name, type, title, description,
+     *                         validationRules, requiredGroups, filterable, sortable,
+     *                         editable, multiple, elementType
+     *
+     * @throws BaseException
+     * @throws TransportException
+     */
+    #[ApiEndpointMetadata(
+        'tasks.task.chat.message.field.list',
+        'https://apidocs.bitrix24.ru/api-reference/rest-v3/tasks/tasks-task-chat-message-field-list.html',
+        'Get list of all available task chat message field descriptors',
+        ApiVersion::v3
+    )]
+    public function list(array $select = []): ChatmessagefieldsResult
+    {
+        $params = $select !== [] ? ['select' => $select] : [];
+
+        return new ChatmessagefieldsResult(
+            $this->core->call('tasks.task.chat.message.field.list', $params, ApiVersion::v3)
+        );
+    }
+}
+```
+
+### 5. `tests/Unit/Services/Task/Chatmessagefield/Service/ChatmessagefieldTest.php`
+
+```php
+#[CoversClass(Chatmessagefield::class)]
+class ChatmessagefieldTest extends TestCase
+{
+    private Chatmessagefield $service;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        $this->service = new Chatmessagefield(new NullCore(), new NullLogger());
+    }
+
+    #[Test]
+    public function testGetReturnsChatmessagefieldResult(): void
+    {
+        $this->assertInstanceOf(
+            ChatmessagefieldResult::class,
+            $this->service->get('taskId')
+        );
+    }
+
+    #[Test]
+    public function testListReturnsChatmessagefieldsResult(): void
+    {
+        $this->assertInstanceOf(
+            ChatmessagefieldsResult::class,
+            $this->service->list()
+        );
+    }
+
+    #[Test]
+    public function testGetThrowsOnEmptyName(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->service->get('');
+    }
+}
+```
+
+### 6. `tests/Integration/Services/Task/Chatmessagefield/Service/ChatmessagefieldTest.php`
+
+No tearDown needed — read-only metadata, no portal state is mutated.
+
+```php
+#[CoversClass(Chatmessagefield::class)]
+class ChatmessagefieldTest extends TestCase
+{
+    use CustomBitrix24Assertions;
+
+    private Chatmessagefield $service;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        $this->service = Factory::getServiceBuilder()->getTaskScope()->chatmessagefield();
+    }
+
+    #[Test]
+    public function testList(): void
+    {
+        $fields = $this->service->list()->getChatmessagefields();
+        $this->assertIsArray($fields);
+        $this->assertNotEmpty($fields);
+    }
+
+    #[Test]
+    public function testGet(): void
+    {
+        $field = $this->service->get('taskId')->chatmessagefield();
+        $this->assertNotEmpty($field->name);
+        $this->assertNotEmpty($field->type);
+        $this->assertNotEmpty($field->title);
+    }
+
+    #[Test]
+    public function testAllFieldsAnnotated(): void
+    {
+        $fields = $this->service->list()->getChatmessagefields();
+        $fieldCodesFromApi = array_keys(
+            $this->service->list([])->getCoreResponse()->getResponseData()->getResult()['items'][0]
+        );
+        $this->assertBitrix24AllResultItemFieldsAnnotated(
+            $fieldCodesFromApi,
+            ChatmessagefieldItemResult::class
+        );
+    }
+}
+```
+
+---
+
+## Files to Modify
+
+### 7. `src/Services/Task/TaskServiceBuilder.php`
+
+Add after `taskChat()` method (line 63):
+
+```php
+public function chatmessagefield(): Chatmessagefield\Service\Chatmessagefield
+{
+    if (!isset($this->serviceCache[__METHOD__])) {
+        $this->serviceCache[__METHOD__] = new Chatmessagefield\Service\Chatmessagefield(
+            $this->core,
+            $this->log
+        );
+    }
+    return $this->serviceCache[__METHOD__];
+}
+```
+
+### 8. `phpunit.xml.dist`
+
+Add after `integration_tests_task` suite (line 189):
+
+```xml
+<testsuite name="integration_tests_task_chatmessagefield">
+    <file>./tests/Integration/Services/Task/Chatmessagefield/Service/ChatmessagefieldTest.php</file>
+</testsuite>
+```
+
+### 9. `Makefile`
+
+Add after `integration_tests_task` target (line ~494):
+
+```makefile
+.PHONY: test-integration-task-chatmessagefield
+test-integration-task-chatmessagefield:
+	docker compose run --rm php-cli vendor/bin/phpunit --testsuite integration_tests_task_chatmessagefield
+```
+
+---
+
+## Deptrac compliance
+
+New service imports only Core-layer symbols (`ApiVersion`, `Scope`, `BaseException`, `TransportException`,
+`AbstractItem`, `AbstractResult`) and `AbstractService` from the same Services layer. Zero new violations.
+
+---
+
+## Verification
+
+```bash
+# Unit tests (fast, no portal)
+make test-unit
+
+# Integration tests for the new service (requires webhook)
+make test-integration-task-chatmessagefield
+
+# Full task integration suite (new test is auto-included)
+make integration_tests_task
+
+# Static analysis
+make lint-phpstan
+make lint-deptrac
+```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@
   - `ChatMessageField::get(string $name, array $select = [])` → `ChatMessageFieldResult` — get a single field descriptor by code (`tasks.task.chat.message.field.get`, API v3)
   - `ChatMessageField::list(array $select = [])` → `ChatMessageFieldsResult` — list all available field descriptors (`tasks.task.chat.message.field.list`, API v3)
   - `ChatMessageFieldItemResult` — field descriptor item with properties: `name`, `type`, `title`, `description`, `validationRules`, `requiredGroups`, `filterable`, `sortable`, `editable`, `multiple`, `elementType`
+- Added `CustomBitrix24Assertions::assertBitrix24ResultItemFieldsTypeCastMatchAnnotations(AbstractItem $item, string $resultItemClassName)` — generic assertion that reads all `@property-read` PHPDoc annotations via Typhoon Reflection and verifies each magic-getter value matches its declared PHP type (supports `string`, `bool`, `int`, `float`, `array`, nullable variants, and class types via `assertInstanceOf`)
+- Added unit tests for `assertBitrix24ResultItemFieldsTypeCastMatchAnnotations` in `tests/Unit/CustomAssertions/CustomBitrix24AssertionsTest.php` covering happy paths (all types match, nullable fields as null) and 9 failure cases via `DataProvider`
+- Added integration tests for `ChatMessageFieldItemResult` in `tests/Integration/Services/Task/ChatMessageField/Result/ChatMessageFieldItemResultTest.php`:
+  - `testAllFieldsAreAnnotated` — verifies every field from raw API response is covered by a `@property-read` annotation
+  - `testAllFieldsHasValidTypeCastingInMagicGetters` — verifies magic getters return values matching their PHPDoc-declared types
 
 ## 3.0.0 - 2026.02.27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@
 
 ### Added
 
+- Added project-level GitHub MCP server configuration (`.mcp.json`) for AI-assisted development with Claude Code
+- Added support for `tasks.task.chat.message.field.*` methods ([#397](https://github.com/bitrix24/b24phpsdk/issues/397)):
+  - `TaskServiceBuilder::taskChatMessageField()` — new scope accessor
+  - `ChatMessageField::get(string $name, array $select = [])` → `ChatMessageFieldResult` — get a single field descriptor by code (`tasks.task.chat.message.field.get`, API v3)
+  - `ChatMessageField::list(array $select = [])` → `ChatMessageFieldsResult` — list all available field descriptors (`tasks.task.chat.message.field.list`, API v3)
+  - `ChatMessageFieldItemResult` — field descriptor item with properties: `name`, `type`, `title`, `description`, `validationRules`, `requiredGroups`, `filterable`, `sortable`, `editable`, `multiple`, `elementType`
+
 ## 3.0.0 - 2026.02.27
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Added
 
 - Added project-level GitHub MCP server configuration (`.mcp.json`) for AI-assisted development with Claude Code
+- Added Claude Code skill `.claude/skills/b24phpsdk-maintainer/SKILL.md` for repository maintainers — enforces conventions when working with GitHub issues
 - Added support for `tasks.task.chat.message.field.*` methods ([#397](https://github.com/bitrix24/b24phpsdk/issues/397)):
   - `TaskServiceBuilder::taskChatMessageField()` — new scope accessor
   - `ChatMessageField::get(string $name, array $select = [])` → `ChatMessageFieldResult` — get a single field descriptor by code (`tasks.task.chat.message.field.get`, API v3)

--- a/Makefile
+++ b/Makefile
@@ -493,6 +493,10 @@ integration_tests_department:
 integration_tests_task:
 	docker compose run --rm php-cli vendor/bin/phpunit --testsuite integration_tests_task
 
+.PHONY: test-integration-task-chat-message-field
+test-integration-task-chat-message-field:
+	docker compose run --rm php-cli vendor/bin/phpunit --testsuite integration_tests_task_chat_message_field
+
 .PHONY: test-integration-legacy-task
 test-integration-legacy-task:
 	docker compose run --rm php-cli vendor/bin/phpunit --testsuite integration_tests_legacy_task

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -189,6 +189,7 @@
         </testsuite>
         <testsuite name="integration_tests_task_chat_message_field">
             <file>./tests/Integration/Services/Task/ChatMessageField/Service/ChatMessageFieldTest.php</file>
+            <file>./tests/Integration/Services/Task/ChatMessageField/Result/ChatMessageFieldItemResultTest.php</file>
         </testsuite>
         <testsuite name="integration_tests_legacy_task">
             <directory>./tests/Integration/Legacy/Services/Task/</directory>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -187,6 +187,9 @@
         <testsuite name="integration_tests_task">
             <directory>./tests/Integration/Services/Task/</directory>
         </testsuite>
+        <testsuite name="integration_tests_task_chat_message_field">
+            <file>./tests/Integration/Services/Task/ChatMessageField/Service/ChatMessageFieldTest.php</file>
+        </testsuite>
         <testsuite name="integration_tests_legacy_task">
             <directory>./tests/Integration/Legacy/Services/Task/</directory>
         </testsuite>

--- a/src/Services/Task/ChatMessageField/Result/ChatMessageFieldItemResult.php
+++ b/src/Services/Task/ChatMessageField/Result/ChatMessageFieldItemResult.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * This file is part of the bitrix24-php-sdk package.
+ *
+ * © Maksim Mesilov <mesilov.maxim@gmail.com>
+ *
+ * For the full copyright and license information, please view the MIT-LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Bitrix24\SDK\Services\Task\ChatMessageField\Result;
+
+use Bitrix24\SDK\Core\Result\AbstractItem;
+
+/**
+ * @property-read string      $name
+ * @property-read string      $type
+ * @property-read string      $title
+ * @property-read string|null $description
+ * @property-read array|null  $validationRules
+ * @property-read array|null  $requiredGroups
+ * @property-read bool        $filterable
+ * @property-read bool        $sortable
+ * @property-read bool        $editable
+ * @property-read bool        $multiple
+ * @property-read string|null $elementType
+ */
+class ChatMessageFieldItemResult extends AbstractItem
+{
+}

--- a/src/Services/Task/ChatMessageField/Result/ChatMessageFieldResult.php
+++ b/src/Services/Task/ChatMessageField/Result/ChatMessageFieldResult.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * This file is part of the bitrix24-php-sdk package.
+ *
+ * © Maksim Mesilov <mesilov.maxim@gmail.com>
+ *
+ * For the full copyright and license information, please view the MIT-LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Bitrix24\SDK\Services\Task\ChatMessageField\Result;
+
+use Bitrix24\SDK\Core\Exceptions\BaseException;
+use Bitrix24\SDK\Core\Result\AbstractResult;
+
+class ChatMessageFieldResult extends AbstractResult
+{
+    /**
+     * @throws BaseException
+     */
+    public function chatMessageField(): ChatMessageFieldItemResult
+    {
+        return new ChatMessageFieldItemResult(
+            $this->getCoreResponse()->getResponseData()->getResult()['item']
+        );
+    }
+}

--- a/src/Services/Task/ChatMessageField/Result/ChatMessageFieldsResult.php
+++ b/src/Services/Task/ChatMessageField/Result/ChatMessageFieldsResult.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * This file is part of the bitrix24-php-sdk package.
+ *
+ * © Maksim Mesilov <mesilov.maxim@gmail.com>
+ *
+ * For the full copyright and license information, please view the MIT-LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Bitrix24\SDK\Services\Task\ChatMessageField\Result;
+
+use Bitrix24\SDK\Core\Exceptions\BaseException;
+use Bitrix24\SDK\Core\Result\AbstractResult;
+
+class ChatMessageFieldsResult extends AbstractResult
+{
+    /**
+     * @return ChatMessageFieldItemResult[]
+     * @throws BaseException
+     */
+    public function getChatMessageFields(): array
+    {
+        $items = [];
+        foreach ($this->getCoreResponse()->getResponseData()->getResult()['items'] as $item) {
+            $items[] = new ChatMessageFieldItemResult($item);
+        }
+
+        return $items;
+    }
+}

--- a/src/Services/Task/ChatMessageField/Service/ChatMessageField.php
+++ b/src/Services/Task/ChatMessageField/Service/ChatMessageField.php
@@ -1,0 +1,88 @@
+<?php
+
+/**
+ * This file is part of the bitrix24-php-sdk package.
+ *
+ * © Maksim Mesilov <mesilov.maxim@gmail.com>
+ *
+ * For the full copyright and license information, please view the MIT-LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Bitrix24\SDK\Services\Task\ChatMessageField\Service;
+
+use Bitrix24\SDK\Attributes\ApiEndpointMetadata;
+use Bitrix24\SDK\Attributes\ApiServiceMetadata;
+use Bitrix24\SDK\Core\Contracts\ApiVersion;
+use Bitrix24\SDK\Core\Credentials\Scope;
+use Bitrix24\SDK\Core\Exceptions\BaseException;
+use Bitrix24\SDK\Core\Exceptions\TransportException;
+use Bitrix24\SDK\Services\AbstractService;
+use Bitrix24\SDK\Services\Task\ChatMessageField\Result\ChatMessageFieldResult;
+use Bitrix24\SDK\Services\Task\ChatMessageField\Result\ChatMessageFieldsResult;
+
+#[ApiServiceMetadata(new Scope(['task']))]
+class ChatMessageField extends AbstractService
+{
+    /**
+     * Get metadata for a single task chat message field by field code.
+     *
+     * @link https://apidocs.bitrix24.ru/api-reference/rest-v3/tasks/tasks-task-chat-message-field-get.html
+     *
+     * @param non-empty-string $name   Field code, e.g. 'taskId'
+     * @param string[]         $select Fields to return. Available: name, type, title, description,
+     *                                 validationRules, requiredGroups, filterable, sortable,
+     *                                 editable, multiple, elementType
+     *
+     * @throws BaseException
+     * @throws TransportException
+     */
+    #[ApiEndpointMetadata(
+        'tasks.task.chat.message.field.get',
+        'https://apidocs.bitrix24.ru/api-reference/rest-v3/tasks/tasks-task-chat-message-field-get.html',
+        'Get metadata for a single task chat message field by field code',
+        ApiVersion::v3
+    )]
+    public function get(string $name, array $select = []): ChatMessageFieldResult
+    {
+        $this->guardNonEmptyString($name, 'field name must not be empty');
+
+        $params = ['name' => $name];
+        if ($select !== []) {
+            $params['select'] = $select;
+        }
+
+        return new ChatMessageFieldResult(
+            $this->core->call('tasks.task.chat.message.field.get', $params, ApiVersion::v3)
+        );
+    }
+
+    /**
+     * Get list of all available task chat message field descriptors.
+     *
+     * @link https://apidocs.bitrix24.ru/api-reference/rest-v3/tasks/tasks-task-chat-message-field-list.html
+     *
+     * @param string[] $select Fields to return. Available: name, type, title, description,
+     *                         validationRules, requiredGroups, filterable, sortable,
+     *                         editable, multiple, elementType
+     *
+     * @throws BaseException
+     * @throws TransportException
+     */
+    #[ApiEndpointMetadata(
+        'tasks.task.chat.message.field.list',
+        'https://apidocs.bitrix24.ru/api-reference/rest-v3/tasks/tasks-task-chat-message-field-list.html',
+        'Get list of all available task chat message field descriptors',
+        ApiVersion::v3
+    )]
+    public function list(array $select = []): ChatMessageFieldsResult
+    {
+        $params = $select !== [] ? ['select' => $select] : [];
+
+        return new ChatMessageFieldsResult(
+            $this->core->call('tasks.task.chat.message.field.list', $params, ApiVersion::v3)
+        );
+    }
+}

--- a/src/Services/Task/Service/TaskItemSelectBuilder.php
+++ b/src/Services/Task/Service/TaskItemSelectBuilder.php
@@ -43,7 +43,7 @@ class TaskItemSelectBuilder extends AbstractSelectBuilder
 
     public function chat(): self
     {
-        $this->select = array_merge($this->select, ['chat.id', 'chat.entityId']);
+        $this->select = array_merge($this->select, ['chat.id', 'chat.entityId', 'chat.entityType']);
         return $this;
     }
 }

--- a/src/Services/Task/TaskServiceBuilder.php
+++ b/src/Services/Task/TaskServiceBuilder.php
@@ -62,6 +62,18 @@ class TaskServiceBuilder extends AbstractServiceBuilder
         return $this->serviceCache[__METHOD__];
     }
 
+    public function taskChatMessageField(): ChatMessageField\Service\ChatMessageField
+    {
+        if (!isset($this->serviceCache[__METHOD__])) {
+            $this->serviceCache[__METHOD__] = new ChatMessageField\Service\ChatMessageField(
+                $this->core,
+                $this->log
+            );
+        }
+
+        return $this->serviceCache[__METHOD__];
+    }
+
     public function taskFile(): Service\TaskFile
     {
         if (!isset($this->serviceCache[__METHOD__])) {

--- a/tests/CustomAssertions/CustomBitrix24Assertions.php
+++ b/tests/CustomAssertions/CustomBitrix24Assertions.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Bitrix24\SDK\Tests\CustomAssertions;
 
+use Bitrix24\SDK\Core\Result\AbstractItem;
 use Bitrix24\SDK\Services\CRM\Activity\ActivityContentType;
 use Bitrix24\SDK\Services\CRM\Activity\ActivityDirectionType;
 use Bitrix24\SDK\Services\CRM\Activity\ActivityNotifyType;
@@ -28,6 +29,53 @@ use Money\Currency;
 trait CustomBitrix24Assertions
 {
     /**
+     * Assert that every property-read field of $resultItemClassName, when accessed via magic getter on $item,
+     * returns a value whose PHP type matches the PHPDoc annotation.
+     *
+     * @param class-string $resultItemClassName
+     */
+    protected function assertBitrix24ResultItemFieldsTypeCastMatchAnnotations(
+        AbstractItem $item,
+        string $resultItemClassName
+    ): void {
+        $props = TyphoonReflector::build()->reflectClass($resultItemClassName)->properties();
+
+        foreach ($props as $meta) {
+            if (!$meta->isAnnotated() || $meta->isNative()) {
+                continue;
+            }
+
+            $propName = $meta->id->name;
+            $typeStr = stringify($meta->type());
+            $value = $item->$propName;
+
+            // null is always valid for nullable types
+            if (str_contains($typeStr, 'null') && $value === null) {
+                continue;
+            }
+
+            $message = sprintf(
+                'field «%s» in «%s» annotated as «%s» but actual PHP type is «%s»',
+                $propName,
+                $resultItemClassName,
+                $typeStr,
+                get_debug_type($value)
+            );
+
+            match (true) {
+                str_contains($typeStr, 'bool')   => $this->assertIsBool($value, $message),
+                str_contains($typeStr, 'int')    => $this->assertIsInt($value, $message),
+                str_contains($typeStr, 'float')  => $this->assertIsFloat($value, $message),
+                str_contains($typeStr, 'string') => $this->assertIsString($value, $message),
+                str_contains($typeStr, 'array')  => $this->assertIsArray($value, $message),
+                default                          => $this->assertInstanceOf($typeStr, $value, $message),
+            };
+        }
+    }
+
+    /**
+     * Check that all result items from api response have fields from class annotation
+     *
      * @param array<int, non-empty-string> $fieldCodesFromApi
      * @param class-string $resultItemClassName
      * @return void
@@ -498,4 +546,6 @@ trait CustomBitrix24Assertions
             }
         }
     }
+
+
 }

--- a/tests/Integration/Services/Task/ChatMessageField/Result/ChatMessageFieldItemResultTest.php
+++ b/tests/Integration/Services/Task/ChatMessageField/Result/ChatMessageFieldItemResultTest.php
@@ -49,7 +49,7 @@ class ChatMessageFieldItemResultTest extends TestCase
     #[TestDox('all fields in ChatMessageFieldItemResult have valid type casting in magic getters')]
     public function testAllFieldsHasValidTypeCastingInMagicGetters(): void
     {
-        $field = $this->chatMessageFieldService->get('taskId')->chatMessageField();
-        $this->assertBitrix24ResultItemFieldsTypeCastMatchAnnotations($field, ChatMessageFieldItemResult::class);
+        $chatMessageFieldItemResult = $this->chatMessageFieldService->get('taskId')->chatMessageField();
+        $this->assertBitrix24ResultItemFieldsTypeCastMatchAnnotations($chatMessageFieldItemResult, ChatMessageFieldItemResult::class);
     }
 }

--- a/tests/Integration/Services/Task/ChatMessageField/Result/ChatMessageFieldItemResultTest.php
+++ b/tests/Integration/Services/Task/ChatMessageField/Result/ChatMessageFieldItemResultTest.php
@@ -39,7 +39,17 @@ class ChatMessageFieldItemResultTest extends TestCase
     #[TestDox('all fields in ChatMessageFieldItemResult are annotated in phpdoc and match with raw api response')]
     public function testAllFieldsAreAnnotated(): void
     {
-        $allFields = $this->chatMessageFieldService->get('taskId')->getCoreResponse()->getResponseData()->getResult()['item'];
+        // get first entity field from documentation
+        $fieldNameForTest = 'taskId';
+        $allFields = $this->chatMessageFieldService->get($fieldNameForTest)->getCoreResponse()->getResponseData()->getResult()['item'];
         $this->assertBitrix24AllResultItemFieldsAnnotated(array_keys($allFields), ChatMessageFieldItemResult::class);
+    }
+
+    #[Test]
+    #[TestDox('all fields in ChatMessageFieldItemResult have valid type casting in magic getters')]
+    public function testAllFieldsHasValidTypeCastingInMagicGetters(): void
+    {
+        $field = $this->chatMessageFieldService->get('taskId')->chatMessageField();
+        $this->assertBitrix24ResultItemFieldsTypeCastMatchAnnotations($field, ChatMessageFieldItemResult::class);
     }
 }

--- a/tests/Integration/Services/Task/ChatMessageField/Result/ChatMessageFieldItemResultTest.php
+++ b/tests/Integration/Services/Task/ChatMessageField/Result/ChatMessageFieldItemResultTest.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * This file is part of the bitrix24-php-sdk package.
+ *
+ * © Maksim Mesilov <mesilov.maxim@gmail.com>
+ *
+ * For the full copyright and license information, please view the MIT-LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Bitrix24\SDK\Tests\Integration\Services\Task\ChatMessageField\Result;
+
+use Bitrix24\SDK\Services\Task\ChatMessageField\Result\ChatMessageFieldItemResult;
+use Bitrix24\SDK\Services\Task\ChatMessageField\Service\ChatMessageField;
+use Bitrix24\SDK\Tests\CustomAssertions\CustomBitrix24Assertions;
+use Bitrix24\SDK\Tests\Integration\Factory;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\TestDox;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ChatMessageFieldItemResult::class)]
+class ChatMessageFieldItemResultTest extends TestCase
+{
+    use CustomBitrix24Assertions;
+
+    private ChatMessageField $chatMessageFieldService;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        $this->chatMessageFieldService = Factory::getServiceBuilder()->getTaskScope()->taskChatMessageField();
+    }
+
+    #[Test]
+    #[TestDox('all fields in ChatMessageFieldItemResult are annotated in phpdoc and match with raw api response')]
+    public function testAllFieldsAreAnnotated(): void
+    {
+        $allFields = $this->chatMessageFieldService->get('taskId')->getCoreResponse()->getResponseData()->getResult()['item'];
+        $this->assertBitrix24AllResultItemFieldsAnnotated(array_keys($allFields), ChatMessageFieldItemResult::class);
+    }
+}

--- a/tests/Integration/Services/Task/ChatMessageField/Service/ChatMessageFieldTest.php
+++ b/tests/Integration/Services/Task/ChatMessageField/Service/ChatMessageFieldTest.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * This file is part of the bitrix24-php-sdk package.
+ *
+ * © Maksim Mesilov <mesilov.maxim@gmail.com>
+ *
+ * For the full copyright and license information, please view the MIT-LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Bitrix24\SDK\Tests\Integration\Services\Task\ChatMessageField\Service;
+
+use Bitrix24\SDK\Services\Task\ChatMessageField\Result\ChatMessageFieldItemResult;
+use Bitrix24\SDK\Services\Task\ChatMessageField\Service\ChatMessageField;
+use Bitrix24\SDK\Tests\CustomAssertions\CustomBitrix24Assertions;
+use Bitrix24\SDK\Tests\Integration\Factory;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ChatMessageField::class)]
+class ChatMessageFieldTest extends TestCase
+{
+    use CustomBitrix24Assertions;
+
+    private ChatMessageField $service;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        $this->service = Factory::getServiceBuilder()->getTaskScope()->taskChatMessageField();
+    }
+
+    #[Test]
+    public function testList(): void
+    {
+        $fields = $this->service->list()->getChatMessageFields();
+        $this->assertIsArray($fields);
+        $this->assertNotEmpty($fields);
+    }
+
+    #[Test]
+    public function testGet(): void
+    {
+        $field = $this->service->get('taskId')->chatMessageField();
+        $this->assertNotEmpty($field->name);
+        $this->assertNotEmpty($field->type);
+        $this->assertNotEmpty($field->title);
+    }
+
+    #[Test]
+    public function testAllFieldsAnnotated(): void
+    {
+        $rawItems = $this->service->list()->getCoreResponse()->getResponseData()->getResult()['items'];
+        $this->assertNotEmpty($rawItems);
+        $fieldCodesFromApi = array_keys($rawItems[0]);
+        $this->assertBitrix24AllResultItemFieldsAnnotated($fieldCodesFromApi, ChatMessageFieldItemResult::class);
+    }
+}

--- a/tests/Integration/Services/Task/ChatMessageField/Service/ChatMessageFieldTest.php
+++ b/tests/Integration/Services/Task/ChatMessageField/Service/ChatMessageFieldTest.php
@@ -45,10 +45,10 @@ class ChatMessageFieldTest extends TestCase
     #[Test]
     public function testGet(): void
     {
-        $field = $this->service->get('taskId')->chatMessageField();
-        $this->assertNotEmpty($field->name);
-        $this->assertNotEmpty($field->type);
-        $this->assertNotEmpty($field->title);
+        $chatMessageFieldItemResult = $this->service->get('taskId')->chatMessageField();
+        $this->assertNotEmpty($chatMessageFieldItemResult->name);
+        $this->assertNotEmpty($chatMessageFieldItemResult->type);
+        $this->assertNotEmpty($chatMessageFieldItemResult->title);
     }
 
     #[Test]

--- a/tests/Integration/Services/Task/ChatMessageField/Service/ChatMessageFieldTest.php
+++ b/tests/Integration/Services/Task/ChatMessageField/Service/ChatMessageFieldTest.php
@@ -59,4 +59,5 @@ class ChatMessageFieldTest extends TestCase
         $fieldCodesFromApi = array_keys($rawItems[0]);
         $this->assertBitrix24AllResultItemFieldsAnnotated($fieldCodesFromApi, ChatMessageFieldItemResult::class);
     }
+
 }

--- a/tests/Unit/CustomAssertions/CustomBitrix24AssertionsTest.php
+++ b/tests/Unit/CustomAssertions/CustomBitrix24AssertionsTest.php
@@ -39,18 +39,18 @@ class CustomBitrix24AssertionsTest extends TestCase
     #[Test]
     public function testPassesWhenAllTypesMatchAnnotations(): void
     {
-        $item = new AllTypesStubItem(self::VALID_DATA);
-        $this->assertBitrix24ResultItemFieldsTypeCastMatchAnnotations($item, AllTypesStubItem::class);
+        $allTypesStubItem = new AllTypesStubItem(self::VALID_DATA);
+        $this->assertBitrix24ResultItemFieldsTypeCastMatchAnnotations($allTypesStubItem, AllTypesStubItem::class);
     }
 
     #[Test]
     public function testPassesWhenNullableFieldsHaveValues(): void
     {
-        $item = new AllTypesStubItem(array_merge(self::VALID_DATA, [
+        $allTypesStubItem = new AllTypesStubItem(array_merge(self::VALID_DATA, [
             'nullableString' => 'world',
             'nullableArray'  => [1, 2, 3],
         ]));
-        $this->assertBitrix24ResultItemFieldsTypeCastMatchAnnotations($item, AllTypesStubItem::class);
+        $this->assertBitrix24ResultItemFieldsTypeCastMatchAnnotations($allTypesStubItem, AllTypesStubItem::class);
     }
 
     #[Test]
@@ -58,8 +58,8 @@ class CustomBitrix24AssertionsTest extends TestCase
     public function testFailsWhenFieldHasWrongType(array $data): void
     {
         $this->expectException(AssertionFailedError::class);
-        $item = new AllTypesStubItem($data);
-        $this->assertBitrix24ResultItemFieldsTypeCastMatchAnnotations($item, AllTypesStubItem::class);
+        $allTypesStubItem = new AllTypesStubItem($data);
+        $this->assertBitrix24ResultItemFieldsTypeCastMatchAnnotations($allTypesStubItem, AllTypesStubItem::class);
     }
 
     public static function wrongTypesDataProvider(): Generator

--- a/tests/Unit/CustomAssertions/CustomBitrix24AssertionsTest.php
+++ b/tests/Unit/CustomAssertions/CustomBitrix24AssertionsTest.php
@@ -1,0 +1,87 @@
+<?php
+
+/**
+ * This file is part of the bitrix24-php-sdk package.
+ *
+ * © Maksim Mesilov <mesilov.maxim@gmail.com>
+ *
+ * For the full copyright and license information, please view the MIT-LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Bitrix24\SDK\Tests\Unit\CustomAssertions;
+
+use Bitrix24\SDK\Core\Result\AbstractItem;
+use Bitrix24\SDK\Tests\CustomAssertions\CustomBitrix24Assertions;
+use Generator;
+use PHPUnit\Framework\AssertionFailedError;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(CustomBitrix24Assertions::class)]
+class CustomBitrix24AssertionsTest extends TestCase
+{
+    use CustomBitrix24Assertions;
+
+    private const array VALID_DATA = [
+        'stringField'   => 'hello',
+        'boolField'     => true,
+        'intField'      => 42,
+        'arrayField'    => ['a', 'b'],
+        'nullableString' => null,
+        'nullableArray'  => null,
+    ];
+
+    #[Test]
+    public function testPassesWhenAllTypesMatchAnnotations(): void
+    {
+        $item = new AllTypesStubItem(self::VALID_DATA);
+        $this->assertBitrix24ResultItemFieldsTypeCastMatchAnnotations($item, AllTypesStubItem::class);
+    }
+
+    #[Test]
+    public function testPassesWhenNullableFieldsHaveValues(): void
+    {
+        $item = new AllTypesStubItem(array_merge(self::VALID_DATA, [
+            'nullableString' => 'world',
+            'nullableArray'  => [1, 2, 3],
+        ]));
+        $this->assertBitrix24ResultItemFieldsTypeCastMatchAnnotations($item, AllTypesStubItem::class);
+    }
+
+    #[Test]
+    #[DataProvider('wrongTypesDataProvider')]
+    public function testFailsWhenFieldHasWrongType(array $data): void
+    {
+        $this->expectException(AssertionFailedError::class);
+        $item = new AllTypesStubItem($data);
+        $this->assertBitrix24ResultItemFieldsTypeCastMatchAnnotations($item, AllTypesStubItem::class);
+    }
+
+    public static function wrongTypesDataProvider(): Generator
+    {
+        yield 'string where bool expected'         => [array_merge(self::VALID_DATA, ['boolField'     => 'true'])];
+        yield 'int where bool expected'            => [array_merge(self::VALID_DATA, ['boolField'     => 1])];
+        yield 'bool where string expected'         => [array_merge(self::VALID_DATA, ['stringField'   => true])];
+        yield 'int where string expected'          => [array_merge(self::VALID_DATA, ['stringField'   => 42])];
+        yield 'string where int expected'          => [array_merge(self::VALID_DATA, ['intField'      => '42'])];
+        yield 'bool where int expected'            => [array_merge(self::VALID_DATA, ['intField'      => false])];
+        yield 'string where array expected'        => [array_merge(self::VALID_DATA, ['arrayField'    => 'arr'])];
+        yield 'int for non-null nullable string'   => [array_merge(self::VALID_DATA, ['nullableString' => 42])];
+        yield 'string for non-null nullable array' => [array_merge(self::VALID_DATA, ['nullableArray'  => 'arr'])];
+    }
+}
+
+/**
+ * @property-read string      $stringField
+ * @property-read bool        $boolField
+ * @property-read int         $intField
+ * @property-read array       $arrayField
+ * @property-read string|null $nullableString
+ * @property-read array|null  $nullableArray
+ */
+class AllTypesStubItem extends AbstractItem {}

--- a/tests/Unit/Services/Task/ChatMessageField/Service/ChatMessageFieldTest.php
+++ b/tests/Unit/Services/Task/ChatMessageField/Service/ChatMessageFieldTest.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * This file is part of the bitrix24-php-sdk package.
+ *
+ * © Maksim Mesilov <mesilov.maxim@gmail.com>
+ *
+ * For the full copyright and license information, please view the MIT-LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Bitrix24\SDK\Tests\Unit\Services\Task\ChatMessageField\Service;
+
+use Bitrix24\SDK\Core\Exceptions\InvalidArgumentException;
+use Bitrix24\SDK\Services\Task\ChatMessageField\Result\ChatMessageFieldResult;
+use Bitrix24\SDK\Services\Task\ChatMessageField\Result\ChatMessageFieldsResult;
+use Bitrix24\SDK\Services\Task\ChatMessageField\Service\ChatMessageField;
+use Bitrix24\SDK\Tests\Unit\Stubs\NullCore;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+#[CoversClass(ChatMessageField::class)]
+class ChatMessageFieldTest extends TestCase
+{
+    private ChatMessageField $service;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        $this->service = new ChatMessageField(new NullCore(), new NullLogger());
+    }
+
+    #[Test]
+    public function testGetReturnsChatMessageFieldResult(): void
+    {
+        $this->assertInstanceOf(
+            ChatMessageFieldResult::class,
+            $this->service->get('taskId')
+        );
+    }
+
+    #[Test]
+    public function testListReturnsChatMessageFieldsResult(): void
+    {
+        $this->assertInstanceOf(
+            ChatMessageFieldsResult::class,
+            $this->service->list()
+        );
+    }
+
+    #[Test]
+    public function testGetThrowsOnEmptyName(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        /** @phpstan-ignore argument.type */
+        $this->service->get('');
+    }
+}


### PR DESCRIPTION
- Implemented support for Bitrix24 REST API methods `tasks.task.chat.message.field.get` and `tasks.task.chat.message.field.list` in API v3.
- Introduced `ChatMessageField` service with `get()` and `list()` methods in `TaskServiceBuilder`.
- Added result classes `ChatMessageFieldResult`, `ChatMessageFieldsResult`, and `ChatMessageFieldItemResult` for handling API responses.
- Updated `CHANGELOG.md`, Makefile targets, PHPUnit configuration, and added unit and integration tests for the new service.

| Q             | A                                                                                                                         |
|---------------|---------------------------------------------------------------------------------------------------------------------------|
| Bug fix?      | no                                                                                                                    |
| New feature?  | yes <!-- please update CHANGELOG.md file -->                                                                           |
| Deprecations? | no <!-- please update CHANGELOG.md file -->                                                                           |
| Issues        | Fix #397 <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead --> |
| License       | **MIT**                                                                                                                       |

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally:
 - Always add tests and ensure they pass.
 - For new features, provide some code snippets to help understand usage.
-->