### PR TITLE
Add `FileField` service for `tasks.task.file.field.*` support

### DIFF
--- a/.claude/skills/b24phpsdk-maintainer/SKILL.md
+++ b/.claude/skills/b24phpsdk-maintainer/SKILL.md
@@ -6,7 +6,7 @@ description: |
   or referencing an issue in commits, branches, or CHANGELOG.
   IMPORTANT: this skill MUST be invoked before doing any issue-related work.
 user-invocable: true
-allowed-tools: mcp__github__get_issue, mcp__github__list_issues, mcp__github__create_issue, mcp__github__add_issue_comment, mcp__github__search_issues
+allowed-tools: mcp__github__get_issue, mcp__github__list_issues, mcp__github__create_issue, mcp__github__add_issue_comment, mcp__github__search_issues, mcp__bitrix24__bitrix-search, mcp__bitrix24__bitrix-method-details, mcp__bitrix24__bitrix-article-details, mcp__bitrix24__bitrix-event-details, mcp__bitrix24__bitrix-app-development-doc-details
 ---
 
 # b24phpsdk Maintainer
@@ -258,11 +258,172 @@ Update the plan file if scope changes during implementation.
 
 ---
 
-## Loading issue details at the start of work
+## Closing an issue: start-of-work protocol
 
-If the user mentions an issue number without explicitly calling `/b24phpsdk-maintainer`, still execute these steps:
+When the user asks to implement (close) an issue and provides a link or number,
+execute the following steps **in strict order** before writing any code.
 
-1. Load the issue via `mcp__github__get_issue`
-2. Output a short summary: what needs to be done
-3. Create `.tasks/<issue-number>/` and write `plan.md`
-4. Propose the plan for review before starting implementation
+### Step 1 — Load the issue
+
+Fetch the issue via `mcp__github__get_issue` and read the full title, body, and labels.
+
+#### Step 1.5 — Expand context from Bitrix24 official documentation
+
+Use the **bitrix24 MCP server** to fetch up-to-date API documentation for every REST method
+mentioned in the issue or required for the implementation.
+
+Available tools:
+
+| Tool | When to use |
+|---|---|
+| `mcp__bitrix24__bitrix-search` | find methods, articles, or events by keyword when the exact name is unknown |
+| `mcp__bitrix24__bitrix-method-details` | fetch full description of a specific REST method (parameters, response shape, errors) |
+| `mcp__bitrix24__bitrix-article-details` | fetch a documentation article (overview pages, concept guides) |
+| `mcp__bitrix24__bitrix-event-details` | fetch details of a specific Bitrix24 event |
+| `mcp__bitrix24__bitrix-app-development-doc-details` | fetch application development documentation |
+
+For each REST method involved in the issue:
+1. Call `mcp__bitrix24__bitrix-method-details` to get the exact parameter names, types, and response structure
+2. Note the real response key names (e.g. `result.item` vs `result.items`) — they must match the `AbstractResult` implementation
+3. Note which API version the method belongs to (v1 or v3) — this determines the base branch
+
+Record findings in the **Context** section of `plan.md` so the plan is grounded in actual API behaviour, not assumptions.
+
+### Step 2 — Determine the type
+
+Classify the issue:
+
+| Type | Signals |
+|---|---|
+| `feature` | labels `enhancement`; title starts with `Add` |
+| `bugfix` | label `bug`; title starts with `Fix` |
+
+Use `feature` if the type is ambiguous.
+
+### Step 3 — Ask which API version
+
+Ask the user explicitly before creating the branch using the `AskUserQuestion` tool
+with the following question and options (do NOT ask via plain text):
+
+```
+question: "Which API version does this issue target?"
+header: "API version"
+options:
+  - label: "v3"
+    description: "REST API v3 — base branch: v3-dev"
+  - label: "v1"
+    description: "REST API v1 — base branch: dev"
+```
+
+Branch off from the corresponding base branch:
+
+| API version | Base branch |
+|---|---|
+| v1 | `dev` |
+| v3 | `v3-dev` |
+
+Do not assume — always wait for the user's answer.
+
+### Step 4 — Create the branch
+
+Name the branch according to the issue type and number:
+
+```
+feature/<issue-number>-<short-slug>   # for features
+bugfix/<issue-number>-<short-slug>    # for bug fixes
+```
+
+Example: `feature/397-add-task-chat-fields` branched from `v3-dev`.
+
+Create it with:
+
+```bash
+git checkout <base-branch>
+git pull
+git checkout -b <branch-name>
+```
+
+### Step 5 — Create the task folder
+
+```
+.tasks/<issue-number>/
+```
+
+### Step 6 — Write the plan and wait for approval
+
+Create `.tasks/<issue-number>/plan.md` using the structure defined in the
+**«Task folder and implementation plan»** section above.
+
+Present the plan to the user and **wait for explicit approval** before writing any production code.
+
+### Step 7 — Review the plan before approval
+
+Before presenting the plan to the user, self-review it against three criteria:
+
+**1. Unambiguity** — every instruction has exactly one possible interpretation.
+Check each step: could a developer unfamiliar with the codebase read it differently?
+If yes — rewrite it to be explicit (add file paths, method names, exact values).
+
+**2. Non-contradiction** — no two instructions conflict with each other.
+Check: do the files to create match what the files to modify expect?
+Do the namespace, class names, and method names stay consistent throughout the plan?
+Do the test skeletons reference the same class names as the source skeletons?
+
+**3. No gaps** — the plan covers the full path from empty branch to passing linters and tests.
+Walk through the acceptance criteria from the issue and verify each one is addressed by at least one step in the plan.
+Check that the Verification section lists all relevant make targets for the changed scope.
+If a step depends on another that is not in the plan — add the missing step.
+
+Only after all three criteria are satisfied, present the plan to the user.
+
+**Required**: before presenting the plan, explicitly report the review results in this format:
+
+```
+Plan review:
+✓ Unambiguity — <one sentence: what was checked and result>
+✓ Non-contradiction — <one sentence: what was checked and result>
+✓ No gaps — <one sentence: what was checked and result>
+```
+
+If any criterion fails, fix the plan first, then re-run the check and report again.
+
+---
+
+## Post-implementation quality gate
+
+After all files from the plan are written and the plan is marked complete,
+run checks in two phases. **Do not start phase 2 until phase 1 is fully green.**
+
+### Phase 1 — Light checks (linters + unit tests)
+
+Run in this order:
+
+```bash
+make lint-phpstan
+make lint-deptrac
+make test-unit
+```
+
+Rules for phase 1:
+- If any command fails, fix the errors and re-run **that command** until it passes before continuing to the next.
+- Do not add entries to `deptrac.yaml` → `skip_violations` to silence a new violation — fix the import instead.
+- Only proceed to phase 2 when all three commands pass without errors.
+
+### Phase 2 — Heavy checks (integration tests)
+
+Run only after phase 1 is fully green:
+
+```bash
+make test-integration-<scope>   # the suite added for this issue
+```
+
+Rules for phase 2:
+- If the suite fails, fix the root cause and re-run until it passes.
+- Do not skip or comment out failing tests — fix the root cause.
+
+### Final report
+
+Report the status to the user:
+- Which commands passed on the first run.
+- Which required fixes, and a one-line summary of what was fixed.
+- Confirmation that both phases are green.

--- a/.tasks/398/plan.md
+++ b/.tasks/398/plan.md
@@ -1,0 +1,192 @@
+# Plan: Add support for tasks.task.file.field.* (issue #398)
+
+## Context
+
+Issue: add SDK support for two REST v3 methods:
+- `tasks.task.file.field.get` — returns `result.item` (single field descriptor) for a given `name`
+- `tasks.task.file.field.list` — returns `result.items` (array of field descriptors)
+
+Both methods belong to the `task` scope and require `ApiVersion::v3`.
+
+Available `select` fields: `name`, `type`, `title`, `description`, `validationRules`,
+`requiredGroups`, `filterable`, `sortable`, `editable`, `multiple`, `elementType`.
+
+Exact structural mirror of `ChatMessageField` (issue #397), which lives at
+`src/Services/Task/ChatMessageField/`. The only differences are:
+- namespace: `FileField` instead of `ChatMessageField`
+- REST method names: `tasks.task.file.field.*` instead of `tasks.task.chat.message.field.*`
+- accessor method names: `fileField()` / `getFileFields()` instead of `chatMessageField()` / `getChatMessageFields()`
+- service builder accessor: `taskFileField()` instead of `taskChatMessageField()`
+
+---
+
+## Files to Create
+
+### 1. `src/Services/Task/FileField/Result/FileFieldItemResult.php`
+
+```php
+namespace Bitrix24\SDK\Services\Task\FileField\Result;
+
+use Bitrix24\SDK\Core\Result\AbstractItem;
+
+/**
+ * @property-read string      $name
+ * @property-read string      $type
+ * @property-read string      $title
+ * @property-read string|null $description
+ * @property-read array|null  $validationRules
+ * @property-read array|null  $requiredGroups
+ * @property-read bool        $filterable
+ * @property-read bool        $sortable
+ * @property-read bool        $editable
+ * @property-read bool        $multiple
+ * @property-read string|null $elementType
+ */
+class FileFieldItemResult extends AbstractItem {}
+```
+
+### 2. `src/Services/Task/FileField/Result/FileFieldResult.php`
+
+```php
+namespace Bitrix24\SDK\Services\Task\FileField\Result;
+
+use Bitrix24\SDK\Core\Result\AbstractResult;
+
+class FileFieldResult extends AbstractResult
+{
+    public function fileField(): FileFieldItemResult
+    {
+        return new FileFieldItemResult(
+            $this->getCoreResponse()->getResponseData()->getResult()['item']
+        );
+    }
+}
+```
+
+### 3. `src/Services/Task/FileField/Result/FileFieldsResult.php`
+
+```php
+namespace Bitrix24\SDK\Services\Task\FileField\Result;
+
+use Bitrix24\SDK\Core\Result\AbstractResult;
+
+class FileFieldsResult extends AbstractResult
+{
+    /** @return FileFieldItemResult[] */
+    public function getFileFields(): array
+    {
+        $items = [];
+        foreach ($this->getCoreResponse()->getResponseData()->getResult()['items'] as $item) {
+            $items[] = new FileFieldItemResult($item);
+        }
+        return $items;
+    }
+}
+```
+
+### 4. `src/Services/Task/FileField/Service/FileField.php`
+
+```php
+namespace Bitrix24\SDK\Services\Task\FileField\Service;
+
+#[ApiServiceMetadata(new Scope(['task']))]
+class FileField extends AbstractService
+{
+    #[ApiEndpointMetadata('tasks.task.file.field.get', '...', '...', ApiVersion::v3)]
+    public function get(string $name, array $select = []): FileFieldResult { ... }
+
+    #[ApiEndpointMetadata('tasks.task.file.field.list', '...', '...', ApiVersion::v3)]
+    public function list(array $select = []): FileFieldsResult { ... }
+}
+```
+
+### 5. `tests/Unit/Services/Task/FileField/Service/FileFieldTest.php`
+
+Three test methods:
+- `testGetReturnsFileFieldResult()` — asserts `instanceof FileFieldResult`
+- `testListReturnsFileFieldsResult()` — asserts `instanceof FileFieldsResult`
+- `testGetThrowsOnEmptyName()` — asserts `InvalidArgumentException` on empty string
+
+Uses `NullCore` + `NullLogger` (no HTTP calls).
+
+### 6. `tests/Integration/Services/Task/FileField/Service/FileFieldTest.php`
+
+Three test methods:
+- `testList()` — calls `list()`, asserts non-empty array of `FileFieldItemResult`
+- `testGet()` — calls `get('taskId')`, asserts `name`, `type`, `title` are non-empty
+- `testAllFieldsAnnotated()` — fetches raw `items[0]` keys and calls `assertBitrix24AllResultItemFieldsAnnotated`
+
+### 7. `tests/Integration/Services/Task/FileField/Result/FileFieldItemResultTest.php`
+
+Two test methods:
+- `testAllFieldsAreAnnotated()` — fetches `result['item']` via `get('taskId')`, calls `assertBitrix24AllResultItemFieldsAnnotated`
+- `testAllFieldsHasValidTypeCastingInMagicGetters()` — calls `assertBitrix24ResultItemFieldsTypeCastMatchAnnotations`
+
+---
+
+## Files to Modify
+
+### 1. `src/Services/Task/TaskServiceBuilder.php`
+
+Add after the `taskChatMessageField()` method:
+
+```php
+public function taskFileField(): FileField\Service\FileField
+{
+    if (!isset($this->serviceCache[__METHOD__])) {
+        $this->serviceCache[__METHOD__] = new FileField\Service\FileField(
+            $this->core,
+            $this->log
+        );
+    }
+    return $this->serviceCache[__METHOD__];
+}
+```
+
+### 2. `phpunit.xml.dist`
+
+Add new testsuite after `integration_tests_task_chat_message_field`:
+
+```xml
+<testsuite name="integration_tests_task_file_field">
+    <file>./tests/Integration/Services/Task/FileField/Service/FileFieldTest.php</file>
+    <file>./tests/Integration/Services/Task/FileField/Result/FileFieldItemResultTest.php</file>
+</testsuite>
+```
+
+### 3. `Makefile`
+
+Add after `test-integration-task-chat-message-field`:
+
+```makefile
+.PHONY: test-integration-task-file-field
+test-integration-task-file-field:
+	docker compose run --rm php-cli vendor/bin/phpunit --testsuite integration_tests_task_file_field
+```
+
+### 4. `CHANGELOG.md`
+
+Under `## Unreleased` → `### Added`:
+
+```markdown
+- Added `tasks.task.file.field.get` and `tasks.task.file.field.list` support via `FileField` service ([#398](https://github.com/bitrix24/b24phpsdk/issues/398))
+```
+
+---
+
+## Deptrac compliance
+
+`FileField` service depends on `Core` only (`AbstractService`, `Scope`, `ApiVersion`, exceptions).
+Result classes depend on `Core` only (`AbstractResult`, `AbstractItem`).
+No cross-service imports. No new deptrac violations.
+
+---
+
+## Verification
+
+```bash
+make test-unit
+make test-integration-task-file-field
+make lint-phpstan
+make lint-deptrac
+```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - Added project-level GitHub MCP server configuration (`.mcp.json`) for AI-assisted development with Claude Code
 - Added Claude Code skill `.claude/skills/b24phpsdk-maintainer/SKILL.md` for repository maintainers — enforces conventions when working with GitHub issues
+- Added support for `tasks.task.file.field.get` and `tasks.task.file.field.list` via `FileField` service ([#398](https://github.com/bitrix24/b24phpsdk/issues/398))
 - Added support for `tasks.task.chat.message.field.*` methods ([#397](https://github.com/bitrix24/b24phpsdk/issues/397)):
   - `TaskServiceBuilder::taskChatMessageField()` — new scope accessor
   - `ChatMessageField::get(string $name, array $select = [])` → `ChatMessageFieldResult` — get a single field descriptor by code (`tasks.task.chat.message.field.get`, API v3)

--- a/Makefile
+++ b/Makefile
@@ -497,6 +497,10 @@ integration_tests_task:
 test-integration-task-chat-message-field:
 	docker compose run --rm php-cli vendor/bin/phpunit --testsuite integration_tests_task_chat_message_field
 
+.PHONY: test-integration-task-file-field
+test-integration-task-file-field:
+	docker compose run --rm php-cli vendor/bin/phpunit --testsuite integration_tests_task_file_field
+
 .PHONY: test-integration-legacy-task
 test-integration-legacy-task:
 	docker compose run --rm php-cli vendor/bin/phpunit --testsuite integration_tests_legacy_task

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -191,6 +191,10 @@
             <file>./tests/Integration/Services/Task/ChatMessageField/Service/ChatMessageFieldTest.php</file>
             <file>./tests/Integration/Services/Task/ChatMessageField/Result/ChatMessageFieldItemResultTest.php</file>
         </testsuite>
+        <testsuite name="integration_tests_task_file_field">
+            <file>./tests/Integration/Services/Task/FileField/Service/FileFieldTest.php</file>
+            <file>./tests/Integration/Services/Task/FileField/Result/FileFieldItemResultTest.php</file>
+        </testsuite>
         <testsuite name="integration_tests_legacy_task">
             <directory>./tests/Integration/Legacy/Services/Task/</directory>
         </testsuite>

--- a/src/Services/Task/FileField/Result/FileFieldItemResult.php
+++ b/src/Services/Task/FileField/Result/FileFieldItemResult.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * This file is part of the bitrix24-php-sdk package.
+ *
+ * © Maksim Mesilov <mesilov.maxim@gmail.com>
+ *
+ * For the full copyright and license information, please view the MIT-LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Bitrix24\SDK\Services\Task\FileField\Result;
+
+use Bitrix24\SDK\Core\Result\AbstractItem;
+
+/**
+ * @property-read string      $name
+ * @property-read string      $type
+ * @property-read string      $title
+ * @property-read string|null $description
+ * @property-read array|null  $validationRules
+ * @property-read array|null  $requiredGroups
+ * @property-read bool        $filterable
+ * @property-read bool        $sortable
+ * @property-read bool        $editable
+ * @property-read bool        $multiple
+ * @property-read string|null $elementType
+ */
+class FileFieldItemResult extends AbstractItem
+{
+}

--- a/src/Services/Task/FileField/Result/FileFieldResult.php
+++ b/src/Services/Task/FileField/Result/FileFieldResult.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * This file is part of the bitrix24-php-sdk package.
+ *
+ * © Maksim Mesilov <mesilov.maxim@gmail.com>
+ *
+ * For the full copyright and license information, please view the MIT-LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Bitrix24\SDK\Services\Task\FileField\Result;
+
+use Bitrix24\SDK\Core\Exceptions\BaseException;
+use Bitrix24\SDK\Core\Result\AbstractResult;
+
+class FileFieldResult extends AbstractResult
+{
+    /**
+     * @throws BaseException
+     */
+    public function fileField(): FileFieldItemResult
+    {
+        return new FileFieldItemResult(
+            $this->getCoreResponse()->getResponseData()->getResult()['item']
+        );
+    }
+}

--- a/src/Services/Task/FileField/Result/FileFieldsResult.php
+++ b/src/Services/Task/FileField/Result/FileFieldsResult.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * This file is part of the bitrix24-php-sdk package.
+ *
+ * © Maksim Mesilov <mesilov.maxim@gmail.com>
+ *
+ * For the full copyright and license information, please view the MIT-LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Bitrix24\SDK\Services\Task\FileField\Result;
+
+use Bitrix24\SDK\Core\Exceptions\BaseException;
+use Bitrix24\SDK\Core\Result\AbstractResult;
+
+class FileFieldsResult extends AbstractResult
+{
+    /**
+     * @return FileFieldItemResult[]
+     * @throws BaseException
+     */
+    public function getFileFields(): array
+    {
+        $items = [];
+        foreach ($this->getCoreResponse()->getResponseData()->getResult()['items'] as $item) {
+            $items[] = new FileFieldItemResult($item);
+        }
+
+        return $items;
+    }
+}

--- a/src/Services/Task/FileField/Service/FileField.php
+++ b/src/Services/Task/FileField/Service/FileField.php
@@ -1,0 +1,88 @@
+<?php
+
+/**
+ * This file is part of the bitrix24-php-sdk package.
+ *
+ * © Maksim Mesilov <mesilov.maxim@gmail.com>
+ *
+ * For the full copyright and license information, please view the MIT-LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Bitrix24\SDK\Services\Task\FileField\Service;
+
+use Bitrix24\SDK\Attributes\ApiEndpointMetadata;
+use Bitrix24\SDK\Attributes\ApiServiceMetadata;
+use Bitrix24\SDK\Core\Contracts\ApiVersion;
+use Bitrix24\SDK\Core\Credentials\Scope;
+use Bitrix24\SDK\Core\Exceptions\BaseException;
+use Bitrix24\SDK\Core\Exceptions\TransportException;
+use Bitrix24\SDK\Services\AbstractService;
+use Bitrix24\SDK\Services\Task\FileField\Result\FileFieldResult;
+use Bitrix24\SDK\Services\Task\FileField\Result\FileFieldsResult;
+
+#[ApiServiceMetadata(new Scope(['task']))]
+class FileField extends AbstractService
+{
+    /**
+     * Get metadata for a single task file field by field code.
+     *
+     * @link https://apidocs.bitrix24.ru/api-reference/rest-v3/tasks/tasks-task-file-field-get.html
+     *
+     * @param non-empty-string $name   Field code, e.g. 'taskId'
+     * @param string[]         $select Fields to return. Available: name, type, title, description,
+     *                                 validationRules, requiredGroups, filterable, sortable,
+     *                                 editable, multiple, elementType
+     *
+     * @throws BaseException
+     * @throws TransportException
+     */
+    #[ApiEndpointMetadata(
+        'tasks.task.file.field.get',
+        'https://apidocs.bitrix24.ru/api-reference/rest-v3/tasks/tasks-task-file-field-get.html',
+        'Get metadata for a single task file field by field code',
+        ApiVersion::v3
+    )]
+    public function get(string $name, array $select = []): FileFieldResult
+    {
+        $this->guardNonEmptyString($name, 'field name must not be empty');
+
+        $params = ['name' => $name];
+        if ($select !== []) {
+            $params['select'] = $select;
+        }
+
+        return new FileFieldResult(
+            $this->core->call('tasks.task.file.field.get', $params, ApiVersion::v3)
+        );
+    }
+
+    /**
+     * Get list of all available task file field descriptors.
+     *
+     * @link https://apidocs.bitrix24.ru/api-reference/rest-v3/tasks/tasks-task-file-field-list.html
+     *
+     * @param string[] $select Fields to return. Available: name, type, title, description,
+     *                         validationRules, requiredGroups, filterable, sortable,
+     *                         editable, multiple, elementType
+     *
+     * @throws BaseException
+     * @throws TransportException
+     */
+    #[ApiEndpointMetadata(
+        'tasks.task.file.field.list',
+        'https://apidocs.bitrix24.ru/api-reference/rest-v3/tasks/tasks-task-file-field-list.html',
+        'Get list of all available task file field descriptors',
+        ApiVersion::v3
+    )]
+    public function list(array $select = []): FileFieldsResult
+    {
+        $params = $select !== [] ? ['select' => $select] : [];
+
+        return new FileFieldsResult(
+            $this->core->call('tasks.task.file.field.list', $params, ApiVersion::v3)
+        );
+    }
+}

--- a/src/Services/Task/TaskServiceBuilder.php
+++ b/src/Services/Task/TaskServiceBuilder.php
@@ -74,6 +74,18 @@ class TaskServiceBuilder extends AbstractServiceBuilder
         return $this->serviceCache[__METHOD__];
     }
 
+    public function taskFileField(): FileField\Service\FileField
+    {
+        if (!isset($this->serviceCache[__METHOD__])) {
+            $this->serviceCache[__METHOD__] = new FileField\Service\FileField(
+                $this->core,
+                $this->log
+            );
+        }
+
+        return $this->serviceCache[__METHOD__];
+    }
+
     public function taskFile(): Service\TaskFile
     {
         if (!isset($this->serviceCache[__METHOD__])) {

--- a/tests/Integration/Services/Task/FileField/Result/FileFieldItemResultTest.php
+++ b/tests/Integration/Services/Task/FileField/Result/FileFieldItemResultTest.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * This file is part of the bitrix24-php-sdk package.
+ *
+ * © Maksim Mesilov <mesilov.maxim@gmail.com>
+ *
+ * For the full copyright and license information, please view the MIT-LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Bitrix24\SDK\Tests\Integration\Services\Task\FileField\Result;
+
+use Bitrix24\SDK\Services\Task\FileField\Result\FileFieldItemResult;
+use Bitrix24\SDK\Services\Task\FileField\Service\FileField;
+use Bitrix24\SDK\Tests\CustomAssertions\CustomBitrix24Assertions;
+use Bitrix24\SDK\Tests\Integration\Factory;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\TestDox;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(FileFieldItemResult::class)]
+class FileFieldItemResultTest extends TestCase
+{
+    use CustomBitrix24Assertions;
+
+    private FileField $fileFieldService;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        $this->fileFieldService = Factory::getServiceBuilder()->getTaskScope()->taskFileField();
+    }
+
+    #[Test]
+    #[TestDox('all fields in FileFieldItemResult are annotated in phpdoc and match with raw api response')]
+    public function testAllFieldsAreAnnotated(): void
+    {
+        $rawItem = $this->fileFieldService->get('id')->getCoreResponse()
+            ->getResponseData()->getResult()['item'];
+
+        $this->assertBitrix24AllResultItemFieldsAnnotated(
+            array_keys($rawItem),
+            FileFieldItemResult::class
+        );
+    }
+
+    #[Test]
+    #[TestDox('all fields in FileFieldItemResult have valid type casting in magic getters')]
+    public function testAllFieldsHasValidTypeCastingInMagicGetters(): void
+    {
+        $fileFieldItemResult = $this->fileFieldService->get('id')->fileField();
+        $this->assertBitrix24ResultItemFieldsTypeCastMatchAnnotations(
+            $fileFieldItemResult,
+            FileFieldItemResult::class
+        );
+    }
+}

--- a/tests/Integration/Services/Task/FileField/Service/FileFieldTest.php
+++ b/tests/Integration/Services/Task/FileField/Service/FileFieldTest.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * This file is part of the bitrix24-php-sdk package.
+ *
+ * © Maksim Mesilov <mesilov.maxim@gmail.com>
+ *
+ * For the full copyright and license information, please view the MIT-LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Bitrix24\SDK\Tests\Integration\Services\Task\FileField\Service;
+
+use Bitrix24\SDK\Services\Task\FileField\Result\FileFieldItemResult;
+use Bitrix24\SDK\Services\Task\FileField\Service\FileField;
+use Bitrix24\SDK\Tests\CustomAssertions\CustomBitrix24Assertions;
+use Bitrix24\SDK\Tests\Integration\Factory;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(FileField::class)]
+class FileFieldTest extends TestCase
+{
+    use CustomBitrix24Assertions;
+
+    private FileField $service;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        $this->service = Factory::getServiceBuilder()->getTaskScope()->taskFileField();
+    }
+
+    #[Test]
+    public function testList(): void
+    {
+        $fields = $this->service->list()->getFileFields();
+        $this->assertIsArray($fields);
+        $this->assertNotEmpty($fields);
+    }
+
+    #[Test]
+    public function testGet(): void
+    {
+        $fileFieldItemResult = $this->service->get('id')->fileField();
+        $this->assertNotEmpty($fileFieldItemResult->name);
+        $this->assertNotEmpty($fileFieldItemResult->type);
+        $this->assertNotEmpty($fileFieldItemResult->title);
+    }
+
+    #[Test]
+    public function testAllFieldsAnnotated(): void
+    {
+        $rawItems = $this->service->list()->getCoreResponse()->getResponseData()->getResult()['items'];
+        $this->assertNotEmpty($rawItems);
+        $fieldCodesFromApi = array_keys($rawItems[0]);
+        $this->assertBitrix24AllResultItemFieldsAnnotated($fieldCodesFromApi, FileFieldItemResult::class);
+    }
+}

--- a/tests/Unit/Services/Task/FileField/Service/FileFieldTest.php
+++ b/tests/Unit/Services/Task/FileField/Service/FileFieldTest.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * This file is part of the bitrix24-php-sdk package.
+ *
+ * © Maksim Mesilov <mesilov.maxim@gmail.com>
+ *
+ * For the full copyright and license information, please view the MIT-LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Bitrix24\SDK\Tests\Unit\Services\Task\FileField\Service;
+
+use Bitrix24\SDK\Core\Exceptions\InvalidArgumentException;
+use Bitrix24\SDK\Services\Task\FileField\Result\FileFieldResult;
+use Bitrix24\SDK\Services\Task\FileField\Result\FileFieldsResult;
+use Bitrix24\SDK\Services\Task\FileField\Service\FileField;
+use Bitrix24\SDK\Tests\Unit\Stubs\NullCore;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+#[CoversClass(FileField::class)]
+class FileFieldTest extends TestCase
+{
+    private FileField $service;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        $this->service = new FileField(new NullCore(), new NullLogger());
+    }
+
+    #[Test]
+    public function testGetReturnsFileFieldResult(): void
+    {
+        $this->assertInstanceOf(
+            FileFieldResult::class,
+            $this->service->get('taskId')
+        );
+    }
+
+    #[Test]
+    public function testListReturnsFileFieldsResult(): void
+    {
+        $this->assertInstanceOf(
+            FileFieldsResult::class,
+            $this->service->list()
+        );
+    }
+
+    #[Test]
+    public function testGetThrowsOnEmptyName(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        /** @phpstan-ignore argument.type */
+        $this->service->get('');
+    }
+}


### PR DESCRIPTION
- Implemented support for Bitrix24 REST API methods `tasks.task.file.field.get` and `tasks.task.file.field.list` in API v3.
- Added `FileField` service with `get()` and `list()` methods in `TaskServiceBuilder`.
- Introduced result classes `FileFieldResult`, `FileFieldsResult`, and `FileFieldItemResult` for handling API responses.
- Updated `CHANGELOG.md`, Makefile targets, PHPUnit configuration, and added unit and integration tests for the new service.

| Q             | A                                                                                                                         |
|---------------|---------------------------------------------------------------------------------------------------------------------------|
| Bug fix?      | no                                                                                                                    |
| New feature?  | yes <!-- please update CHANGELOG.md file -->                                                                           |
| Deprecations? | no <!-- please update CHANGELOG.md file -->                                                                           |
| Issues        | Fix #398  <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead --> |
| License       | **MIT**                                                                                                                       |

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally:
 - Always add tests and ensure they pass.
 - For new features, provide some code snippets to help understand usage.
-->