### PR TITLE
Add EventLogField service for main.eventlog.field.* support

### DIFF
--- a/.claude/skills/b24phpsdk-maintainer/SKILL.md
+++ b/.claude/skills/b24phpsdk-maintainer/SKILL.md
@@ -526,7 +526,7 @@ Use its exact structure as the PR body. Fill in every placeholder and replace ev
 comment block with real content derived from the implementation and the issue.
 Do NOT use a memorised or hardcoded body structure — always re-read the file.
 
-After filling in the template, append the quality gate results:
+After filling in the template, append the quality gate results and the issue closing keyword:
 
 ```
 ## Test plan
@@ -538,8 +538,14 @@ After filling in the template, append the quality gate results:
 - [x] `make test-unit` — passed
 - [x] `make test-integration-<scope>` — passed
 
+Closes #<issue-number>
+
 🤖 Generated with [Claude Code](https://claude.ai/claude-code)
 ```
+
+**Why `Closes #NNN` outside the table**: GitHub only activates automatic issue linking and
+the "Linked issues" sidebar when the closing keyword appears as plain text in the body —
+not inside Markdown tables, code blocks, or HTML comments.
 
 Use `mcp__github__create_pull_request` (preferred) or `gh pr create` with the following parameters:
 
@@ -549,7 +555,7 @@ repo:      b24phpsdk
 title:     <issue title, max 72 characters>
 head:      <branch-name>
 base:      <base-branch>   # v3-dev or dev — same as when the branch was created
-body:      <filled-in template + quality gate results>
+body:      <filled-in template + quality gate results + Closes #NNN>
 assignees: [<author login from step 2>]
 milestone: <milestone number from step 3>
 ```

--- a/.claude/skills/b24phpsdk-maintainer/SKILL.md
+++ b/.claude/skills/b24phpsdk-maintainer/SKILL.md
@@ -268,6 +268,7 @@ into the existing SDK structure, any constraints or decisions made upfront>
 
 \`\`\`bash
 make lint-cs-fixer
+make lint-rector
 make lint-phpstan
 make lint-deptrac
 make test-unit
@@ -423,6 +424,7 @@ Run in this order:
 
 ```bash
 make lint-cs-fixer
+make lint-rector
 make lint-phpstan
 make lint-deptrac
 make test-unit
@@ -431,7 +433,7 @@ make test-unit
 Rules for phase 1:
 - If any command fails, fix the errors and re-run **that command** until it passes before continuing to the next.
 - Do not add entries to `deptrac.yaml` → `skip_violations` to silence a new violation — fix the import instead.
-- Only proceed to phase 2 when all four commands pass without errors.
+- Only proceed to phase 2 when all five commands pass without errors.
 
 ### Phase 2 — Heavy checks (integration tests)
 
@@ -543,6 +545,7 @@ milestone: <milestone number from step 3>
 ## Test plan
 
 - [x] `make lint-cs-fixer` — passed
+- [x] `make lint-rector` — passed
 - [x] `make lint-phpstan` — passed
 - [x] `make lint-deptrac` — passed
 - [x] `make test-unit` — passed

--- a/.claude/skills/b24phpsdk-maintainer/SKILL.md
+++ b/.claude/skills/b24phpsdk-maintainer/SKILL.md
@@ -516,43 +516,17 @@ If no matching milestone exists, omit the `milestone` field.
 
 ### Step 4 — Create the Pull Request
 
-**Before composing the PR body**, read the project's PR template:
+**Before composing the PR body**, read the template fresh from disk:
 
 ```bash
 cat .github/PULL_REQUEST_TEMPLATE.md
 ```
 
-Fill in every field of that template with actual values from the implementation.
-Do NOT invent your own body structure — always use the template as the base.
+Use its exact structure as the PR body. Fill in every placeholder and replace every
+comment block with real content derived from the implementation and the issue.
+Do NOT use a memorised or hardcoded body structure — always re-read the file.
 
-Use `mcp__github__create_pull_request` (preferred) or `gh pr create` with the following parameters:
-
-```
-owner:     bitrix24
-repo:      b24phpsdk
-title:     <issue title, max 72 characters>
-head:      <branch-name>
-base:      <base-branch>   # v3-dev or dev — same as when the branch was created
-body:      <filled-in PULL_REQUEST_TEMPLATE.md — see instructions below>
-assignees: [<author login from step 2>]
-milestone: <milestone number from step 3>
-```
-
-#### How to fill in PULL_REQUEST_TEMPLATE.md
-
-The template contains a table and a comment block. Fill them as follows:
-
-| Field | How to fill |
-|---|---|
-| `Bug fix?` | `yes` if issue label is `bug`, otherwise `no` |
-| `New feature?` | `yes` if issue label is `enhancement`, otherwise `no` |
-| `Deprecations?` | `yes` if any public API was deprecated, otherwise `no` |
-| `Issues` | `Fix #<issue-number>` |
-| `License` | keep `**MIT**` as-is |
-
-Replace the comment block (`<!-- Replace this notice ... -->`) with:
-- A short description of what was added or fixed
-- The Phase 1 + Phase 2 quality gate results in this format:
+After filling in the template, append the quality gate results:
 
 ```
 ## Test plan
@@ -565,6 +539,19 @@ Replace the comment block (`<!-- Replace this notice ... -->`) with:
 - [x] `make test-integration-<scope>` — passed
 
 🤖 Generated with [Claude Code](https://claude.ai/claude-code)
+```
+
+Use `mcp__github__create_pull_request` (preferred) or `gh pr create` with the following parameters:
+
+```
+owner:     bitrix24
+repo:      b24phpsdk
+title:     <issue title, max 72 characters>
+head:      <branch-name>
+base:      <base-branch>   # v3-dev or dev — same as when the branch was created
+body:      <filled-in template + quality gate results>
+assignees: [<author login from step 2>]
+milestone: <milestone number from step 3>
 ```
 
 ### Step 5 — Return the PR URL

--- a/.claude/skills/b24phpsdk-maintainer/SKILL.md
+++ b/.claude/skills/b24phpsdk-maintainer/SKILL.md
@@ -516,7 +516,16 @@ If no matching milestone exists, omit the `milestone` field.
 
 ### Step 4 — Create the Pull Request
 
-Use `mcp__github__create_pull_request` with the following parameters:
+**Before composing the PR body**, read the project's PR template:
+
+```bash
+cat .github/PULL_REQUEST_TEMPLATE.md
+```
+
+Fill in every field of that template with actual values from the implementation.
+Do NOT invent your own body structure — always use the template as the base.
+
+Use `mcp__github__create_pull_request` (preferred) or `gh pr create` with the following parameters:
 
 ```
 owner:     bitrix24
@@ -524,24 +533,28 @@ repo:      b24phpsdk
 title:     <issue title, max 72 characters>
 head:      <branch-name>
 base:      <base-branch>   # v3-dev or dev — same as when the branch was created
-body:      <see template below>
+body:      <filled-in PULL_REQUEST_TEMPLATE.md — see instructions below>
 assignees: [<author login from step 2>]
 milestone: <milestone number from step 3>
 ```
 
-#### PR body template
+#### How to fill in PULL_REQUEST_TEMPLATE.md
 
-```markdown
-## Summary
+The template contains a table and a comment block. Fill them as follows:
 
-- Closes #<issue-number>
-- <one-line description of what was added/fixed>
+| Field | How to fill |
+|---|---|
+| `Bug fix?` | `yes` if issue label is `bug`, otherwise `no` |
+| `New feature?` | `yes` if issue label is `enhancement`, otherwise `no` |
+| `Deprecations?` | `yes` if any public API was deprecated, otherwise `no` |
+| `Issues` | `Fix #<issue-number>` |
+| `License` | keep `**MIT**` as-is |
 
-## Changes
+Replace the comment block (`<!-- Replace this notice ... -->`) with:
+- A short description of what was added or fixed
+- The Phase 1 + Phase 2 quality gate results in this format:
 
-- <bullet: file or component changed and why>
-- <bullet: ...>
-
+```
 ## Test plan
 
 - [x] `make lint-cs-fixer` — passed

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,7 @@
 | New feature?  | yes/no <!-- please update CHANGELOG.md file -->                                                                           |
 | Deprecations? | yes/no <!-- please update CHANGELOG.md file -->                                                                           |
 | Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead --> |
-| License       | **MIT**                                                                                                                       |
+| License       | **MIT**                                                                                                                   |
 
 <!--
 Replace this notice by a description of your feature/bugfix.
@@ -14,3 +14,5 @@ Additionally:
  - Always add tests and ensure they pass.
  - For new features, provide some code snippets to help understand usage.
 -->
+
+Closes #...

--- a/.tasks/394/plan.md
+++ b/.tasks/394/plan.md
@@ -1,0 +1,391 @@
+# Plan: Add support for main.eventlog.field.* (issue #394)
+
+## Context
+
+Issue #394 requests support for two REST API v3 methods:
+- `main.eventlog.field.get` — returns metadata for a single event log field by name
+- `main.eventlog.field.list` — returns list of all available event log field descriptors
+
+Both methods belong to `scope: main`.
+
+**API response shapes (confirmed from official docs):**
+- `field.get` → `result.item` (single object)
+- `field.list` → `result.items` (array of objects)
+
+**Field descriptor properties** (available via `select`):
+`name`, `type`, `title`, `description`, `validationRules`, `requiredGroups`,
+`filterable`, `sortable`, `editable`, `multiple`, `elementType`
+
+**Implementation pattern**: identical to `src/Services/Task/ChatMessageField/` —
+new sub-directory under `src/Services/Main/EventLogField/` with `Service/` and `Result/` sub-directories.
+
+**Base branch**: `v3-dev`. Branch: `feature/394-add-main-eventlog-field`.
+
+---
+
+## Files to Create
+
+### 1. `src/Services/Main/EventLogField/Result/EventLogFieldItemResult.php`
+
+```php
+<?php
+declare(strict_types=1);
+namespace Bitrix24\SDK\Services\Main\EventLogField\Result;
+
+use Bitrix24\SDK\Core\Result\AbstractItem;
+
+/**
+ * @property-read string      $name
+ * @property-read string      $type
+ * @property-read string      $title
+ * @property-read string|null $description
+ * @property-read array|null  $validationRules
+ * @property-read array|null  $requiredGroups
+ * @property-read bool        $filterable
+ * @property-read bool        $sortable
+ * @property-read bool        $editable
+ * @property-read bool        $multiple
+ * @property-read string|null $elementType
+ */
+class EventLogFieldItemResult extends AbstractItem {}
+```
+
+### 2. `src/Services/Main/EventLogField/Result/EventLogFieldResult.php`
+
+```php
+<?php
+declare(strict_types=1);
+namespace Bitrix24\SDK\Services\Main\EventLogField\Result;
+
+use Bitrix24\SDK\Core\Exceptions\BaseException;
+use Bitrix24\SDK\Core\Result\AbstractResult;
+
+class EventLogFieldResult extends AbstractResult
+{
+    /** @throws BaseException */
+    public function eventLogField(): EventLogFieldItemResult
+    {
+        return new EventLogFieldItemResult(
+            $this->getCoreResponse()->getResponseData()->getResult()['item']
+        );
+    }
+}
+```
+
+### 3. `src/Services/Main/EventLogField/Result/EventLogFieldsResult.php`
+
+```php
+<?php
+declare(strict_types=1);
+namespace Bitrix24\SDK\Services\Main\EventLogField\Result;
+
+use Bitrix24\SDK\Core\Exceptions\BaseException;
+use Bitrix24\SDK\Core\Result\AbstractResult;
+
+class EventLogFieldsResult extends AbstractResult
+{
+    /**
+     * @return EventLogFieldItemResult[]
+     * @throws BaseException
+     */
+    public function getEventLogFields(): array
+    {
+        $items = [];
+        foreach ($this->getCoreResponse()->getResponseData()->getResult()['items'] as $item) {
+            $items[] = new EventLogFieldItemResult($item);
+        }
+        return $items;
+    }
+}
+```
+
+### 4. `src/Services/Main/EventLogField/Service/EventLogField.php`
+
+```php
+<?php
+declare(strict_types=1);
+namespace Bitrix24\SDK\Services\Main\EventLogField\Service;
+
+use Bitrix24\SDK\Attributes\ApiEndpointMetadata;
+use Bitrix24\SDK\Attributes\ApiServiceMetadata;
+use Bitrix24\SDK\Core\Contracts\ApiVersion;
+use Bitrix24\SDK\Core\Credentials\Scope;
+use Bitrix24\SDK\Core\Exceptions\BaseException;
+use Bitrix24\SDK\Core\Exceptions\TransportException;
+use Bitrix24\SDK\Services\AbstractService;
+use Bitrix24\SDK\Services\Main\EventLogField\Result\EventLogFieldResult;
+use Bitrix24\SDK\Services\Main\EventLogField\Result\EventLogFieldsResult;
+
+#[ApiServiceMetadata(new Scope(['main']))]
+class EventLogField extends AbstractService
+{
+    /**
+     * Get metadata for a single event log field by name.
+     *
+     * @link https://apidocs.bitrix24.ru/api-reference/rest-v3/main/main-eventlog-field-get.html
+     *
+     * @param non-empty-string $name   Field code, e.g. 'timestampX'
+     * @param string[]         $select Fields to return.
+     *
+     * @throws BaseException
+     * @throws TransportException
+     */
+    #[ApiEndpointMetadata(
+        'main.eventlog.field.get',
+        'https://apidocs.bitrix24.ru/api-reference/rest-v3/main/main-eventlog-field-get.html',
+        'Get metadata for a single event log field by name',
+        ApiVersion::v3
+    )]
+    public function get(string $name, array $select = []): EventLogFieldResult
+    {
+        $this->guardNonEmptyString($name, 'field name must not be empty');
+
+        $params = ['name' => $name];
+        if ($select !== []) {
+            $params['select'] = $select;
+        }
+
+        return new EventLogFieldResult(
+            $this->core->call('main.eventlog.field.get', $params, ApiVersion::v3)
+        );
+    }
+
+    /**
+     * Get list of all available event log field descriptors.
+     *
+     * @link https://apidocs.bitrix24.ru/api-reference/rest-v3/main/main-eventlog-field-list.html
+     *
+     * @param string[] $select Fields to return.
+     *
+     * @throws BaseException
+     * @throws TransportException
+     */
+    #[ApiEndpointMetadata(
+        'main.eventlog.field.list',
+        'https://apidocs.bitrix24.ru/api-reference/rest-v3/main/main-eventlog-field-list.html',
+        'Get list of all available event log field descriptors',
+        ApiVersion::v3
+    )]
+    public function list(array $select = []): EventLogFieldsResult
+    {
+        $params = $select !== [] ? ['select' => $select] : [];
+
+        return new EventLogFieldsResult(
+            $this->core->call('main.eventlog.field.list', $params, ApiVersion::v3)
+        );
+    }
+}
+```
+
+### 5. `tests/Unit/Services/Main/EventLogField/Service/EventLogFieldTest.php`
+
+```php
+<?php
+declare(strict_types=1);
+namespace Bitrix24\SDK\Tests\Unit\Services\Main\EventLogField\Service;
+
+use Bitrix24\SDK\Core\Exceptions\InvalidArgumentException;
+use Bitrix24\SDK\Services\Main\EventLogField\Result\EventLogFieldResult;
+use Bitrix24\SDK\Services\Main\EventLogField\Result\EventLogFieldsResult;
+use Bitrix24\SDK\Services\Main\EventLogField\Service\EventLogField;
+use Bitrix24\SDK\Tests\Unit\Stubs\NullCore;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+#[CoversClass(EventLogField::class)]
+class EventLogFieldTest extends TestCase
+{
+    private EventLogField $service;
+
+    protected function setUp(): void
+    {
+        $this->service = new EventLogField(new NullCore(), new NullLogger());
+    }
+
+    #[Test]
+    public function testGetReturnsEventLogFieldResult(): void
+    {
+        $this->assertInstanceOf(EventLogFieldResult::class, $this->service->get('timestampX'));
+    }
+
+    #[Test]
+    public function testListReturnsEventLogFieldsResult(): void
+    {
+        $this->assertInstanceOf(EventLogFieldsResult::class, $this->service->list());
+    }
+
+    #[Test]
+    public function testGetThrowsOnEmptyName(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        /** @phpstan-ignore argument.type */
+        $this->service->get('');
+    }
+}
+```
+
+### 6. `tests/Integration/Services/Main/EventLogField/Service/EventLogFieldTest.php`
+
+```php
+<?php
+declare(strict_types=1);
+namespace Bitrix24\SDK\Tests\Integration\Services\Main\EventLogField\Service;
+
+use Bitrix24\SDK\Services\Main\EventLogField\Result\EventLogFieldItemResult;
+use Bitrix24\SDK\Services\Main\EventLogField\Service\EventLogField;
+use Bitrix24\SDK\Tests\CustomAssertions\CustomBitrix24Assertions;
+use Bitrix24\SDK\Tests\Integration\Factory;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(EventLogField::class)]
+class EventLogFieldTest extends TestCase
+{
+    use CustomBitrix24Assertions;
+
+    private EventLogField $service;
+
+    protected function setUp(): void
+    {
+        $this->service = Factory::getServiceBuilder()->getMainScope()->eventLogField();
+    }
+
+    #[Test]
+    public function testList(): void
+    {
+        $fields = $this->service->list()->getEventLogFields();
+        $this->assertIsArray($fields);
+        $this->assertNotEmpty($fields);
+    }
+
+    #[Test]
+    public function testGet(): void
+    {
+        $field = $this->service->get('timestampX')->eventLogField();
+        $this->assertNotEmpty($field->name);
+        $this->assertNotEmpty($field->type);
+        $this->assertNotEmpty($field->title);
+    }
+
+    #[Test]
+    public function testAllFieldsAnnotated(): void
+    {
+        $rawItems = $this->service->list()->getCoreResponse()->getResponseData()->getResult()['items'];
+        $this->assertNotEmpty($rawItems);
+        $this->assertBitrix24AllResultItemFieldsAnnotated(array_keys($rawItems[0]), EventLogFieldItemResult::class);
+    }
+}
+```
+
+### 7. `tests/Integration/Services/Main/EventLogField/Result/EventLogFieldItemResultTest.php`
+
+```php
+<?php
+declare(strict_types=1);
+namespace Bitrix24\SDK\Tests\Integration\Services\Main\EventLogField\Result;
+
+use Bitrix24\SDK\Services\Main\EventLogField\Result\EventLogFieldItemResult;
+use Bitrix24\SDK\Services\Main\EventLogField\Service\EventLogField;
+use Bitrix24\SDK\Tests\CustomAssertions\CustomBitrix24Assertions;
+use Bitrix24\SDK\Tests\Integration\Factory;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\TestDox;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(EventLogFieldItemResult::class)]
+class EventLogFieldItemResultTest extends TestCase
+{
+    use CustomBitrix24Assertions;
+
+    private EventLogField $eventLogFieldService;
+
+    protected function setUp(): void
+    {
+        $this->eventLogFieldService = Factory::getServiceBuilder()->getMainScope()->eventLogField();
+    }
+
+    #[Test]
+    #[TestDox('all fields in EventLogFieldItemResult are annotated in phpdoc and match with raw api response')]
+    public function testAllFieldsAreAnnotated(): void
+    {
+        $allFields = $this->eventLogFieldService->get('timestampX')
+            ->getCoreResponse()->getResponseData()->getResult()['item'];
+        $this->assertBitrix24AllResultItemFieldsAnnotated(array_keys($allFields), EventLogFieldItemResult::class);
+    }
+
+    #[Test]
+    #[TestDox('all fields in EventLogFieldItemResult have valid type casting in magic getters')]
+    public function testAllFieldsHasValidTypeCastingInMagicGetters(): void
+    {
+        $eventLogFieldItemResult = $this->eventLogFieldService->get('timestampX')->eventLogField();
+        $this->assertBitrix24ResultItemFieldsTypeCastMatchAnnotations(
+            $eventLogFieldItemResult,
+            EventLogFieldItemResult::class
+        );
+    }
+}
+```
+
+---
+
+## Files to Modify
+
+### 1. `src/Services/Main/MainServiceBuilder.php`
+
+Add import:
+```php
+use Bitrix24\SDK\Services\Main\EventLogField\Service\EventLogField;
+```
+
+Add method after `eventLog()`:
+```php
+public function eventLogField(): EventLogField
+{
+    if (!isset($this->serviceCache[__METHOD__])) {
+        $this->serviceCache[__METHOD__] = new EventLogField($this->core, $this->log);
+    }
+    return $this->serviceCache[__METHOD__];
+}
+```
+
+### 2. `phpunit.xml.dist`
+
+Replace the existing `integration_tests_scope_main_eventlog` suite:
+```xml
+<testsuite name="integration_tests_scope_main_eventlog">
+    <file>./tests/Integration/Services/Main/Service/EventLogTest.php</file>
+    <file>./tests/Integration/Services/Main/EventLogField/Service/EventLogFieldTest.php</file>
+    <file>./tests/Integration/Services/Main/EventLogField/Result/EventLogFieldItemResultTest.php</file>
+</testsuite>
+```
+
+### 3. `CHANGELOG.md`
+
+Under `## 3.1.0 Unreleased` → `### Added`:
+```markdown
+- Added `EventLogField` service for `main.eventlog.field.*` support ([#394](https://github.com/bitrix24/b24phpsdk/issues/394))
+```
+
+---
+
+## Deptrac compliance
+
+`EventLogField` service is in `Services` layer.
+It imports only from `Core` (`AbstractService`, `ApiVersion`, `Scope`, `BaseException`, `TransportException`) and its own `Result` classes.
+No imports from `Application`, `Infrastructure`, or other `Services` — no new violations.
+
+---
+
+## Verification
+
+```bash
+make lint-cs-fixer
+make lint-phpstan
+make lint-deptrac
+make test-unit
+make test-integration-main-eventlog
+```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - `ContactPersonInterface::getBitrix24UserId()` now returns `int` instead of `?int` — a ContactPerson is always linked to a Bitrix24 user ([#365](https://github.com/bitrix24/b24phpsdk/issues/365))
 - Updated `.claude/skills/b24phpsdk-maintainer/SKILL.md`: added `make lint-rector` to Phase 1 quality gate and PR test plan checklist to prevent missed Rector violations in CI
+- Updated `.claude/skills/b24phpsdk-maintainer/SKILL.md`: PR body must now be built from `.github/PULL_REQUEST_TEMPLATE.md` instead of a hardcoded template
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - Added project-level GitHub MCP server configuration (`.mcp.json`) for AI-assisted development with Claude Code
 - Added Claude Code skill `.claude/skills/b24phpsdk-maintainer/SKILL.md` for repository maintainers — enforces conventions when working with GitHub issues
+- Added `EventLogField` service for `main.eventlog.field.get` and `main.eventlog.field.list` support ([#394](https://github.com/bitrix24/b24phpsdk/issues/394))
 - Added support for `tasks.task.access.field.get` and `tasks.task.access.field.list` via `AccessField` service ([#396](https://github.com/bitrix24/b24phpsdk/issues/396))
 - Added support for `tasks.task.file.field.get` and `tasks.task.file.field.list` via `FileField` service ([#398](https://github.com/bitrix24/b24phpsdk/issues/398))
 - Added support for `tasks.task.chat.message.field.*` methods ([#397](https://github.com/bitrix24/b24phpsdk/issues/397)):

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Changed
 
 - `ContactPersonInterface::getBitrix24UserId()` now returns `int` instead of `?int` — a ContactPerson is always linked to a Bitrix24 user ([#365](https://github.com/bitrix24/b24phpsdk/issues/365))
+- Updated `.claude/skills/b24phpsdk-maintainer/SKILL.md`: added `make lint-rector` to Phase 1 quality gate and PR test plan checklist to prevent missed Rector violations in CI
 
 ### Added
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -285,6 +285,8 @@
         </testsuite>
         <testsuite name="integration_tests_scope_main_eventlog">
             <file>./tests/Integration/Services/Main/Service/EventLogTest.php</file>
+            <file>./tests/Integration/Services/Main/EventLogField/Service/EventLogFieldTest.php</file>
+            <file>./tests/Integration/Services/Main/EventLogField/Result/EventLogFieldItemResultTest.php</file>
         </testsuite>
     </testsuites>
     <source>

--- a/src/Services/Main/EventLogField/Result/EventLogFieldItemResult.php
+++ b/src/Services/Main/EventLogField/Result/EventLogFieldItemResult.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * This file is part of the bitrix24-php-sdk package.
+ *
+ * © Maksim Mesilov <mesilov.maxim@gmail.com>
+ *
+ * For the full copyright and license information, please view the MIT-LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Bitrix24\SDK\Services\Main\EventLogField\Result;
+
+use Bitrix24\SDK\Core\Result\AbstractItem;
+
+/**
+ * @property-read string      $name
+ * @property-read string      $type
+ * @property-read string      $title
+ * @property-read string|null $description
+ * @property-read array|null  $validationRules
+ * @property-read array|null  $requiredGroups
+ * @property-read bool        $filterable
+ * @property-read bool        $sortable
+ * @property-read bool        $editable
+ * @property-read bool        $multiple
+ * @property-read string|null $elementType
+ */
+class EventLogFieldItemResult extends AbstractItem
+{
+}

--- a/src/Services/Main/EventLogField/Result/EventLogFieldResult.php
+++ b/src/Services/Main/EventLogField/Result/EventLogFieldResult.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * This file is part of the bitrix24-php-sdk package.
+ *
+ * © Maksim Mesilov <mesilov.maxim@gmail.com>
+ *
+ * For the full copyright and license information, please view the MIT-LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Bitrix24\SDK\Services\Main\EventLogField\Result;
+
+use Bitrix24\SDK\Core\Exceptions\BaseException;
+use Bitrix24\SDK\Core\Result\AbstractResult;
+
+class EventLogFieldResult extends AbstractResult
+{
+    /**
+     * @throws BaseException
+     */
+    public function eventLogField(): EventLogFieldItemResult
+    {
+        return new EventLogFieldItemResult(
+            $this->getCoreResponse()->getResponseData()->getResult()['item']
+        );
+    }
+}

--- a/src/Services/Main/EventLogField/Result/EventLogFieldsResult.php
+++ b/src/Services/Main/EventLogField/Result/EventLogFieldsResult.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * This file is part of the bitrix24-php-sdk package.
+ *
+ * © Maksim Mesilov <mesilov.maxim@gmail.com>
+ *
+ * For the full copyright and license information, please view the MIT-LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Bitrix24\SDK\Services\Main\EventLogField\Result;
+
+use Bitrix24\SDK\Core\Exceptions\BaseException;
+use Bitrix24\SDK\Core\Result\AbstractResult;
+
+class EventLogFieldsResult extends AbstractResult
+{
+    /**
+     * @return EventLogFieldItemResult[]
+     * @throws BaseException
+     */
+    public function getEventLogFields(): array
+    {
+        $items = [];
+        foreach ($this->getCoreResponse()->getResponseData()->getResult()['items'] as $item) {
+            $items[] = new EventLogFieldItemResult($item);
+        }
+
+        return $items;
+    }
+}

--- a/src/Services/Main/EventLogField/Service/EventLogField.php
+++ b/src/Services/Main/EventLogField/Service/EventLogField.php
@@ -1,0 +1,88 @@
+<?php
+
+/**
+ * This file is part of the bitrix24-php-sdk package.
+ *
+ * © Maksim Mesilov <mesilov.maxim@gmail.com>
+ *
+ * For the full copyright and license information, please view the MIT-LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Bitrix24\SDK\Services\Main\EventLogField\Service;
+
+use Bitrix24\SDK\Attributes\ApiEndpointMetadata;
+use Bitrix24\SDK\Attributes\ApiServiceMetadata;
+use Bitrix24\SDK\Core\Contracts\ApiVersion;
+use Bitrix24\SDK\Core\Credentials\Scope;
+use Bitrix24\SDK\Core\Exceptions\BaseException;
+use Bitrix24\SDK\Core\Exceptions\TransportException;
+use Bitrix24\SDK\Services\AbstractService;
+use Bitrix24\SDK\Services\Main\EventLogField\Result\EventLogFieldResult;
+use Bitrix24\SDK\Services\Main\EventLogField\Result\EventLogFieldsResult;
+
+#[ApiServiceMetadata(new Scope(['main']))]
+class EventLogField extends AbstractService
+{
+    /**
+     * Get metadata for a single event log field by name.
+     *
+     * @link https://apidocs.bitrix24.ru/api-reference/rest-v3/main/main-eventlog-field-get.html
+     *
+     * @param non-empty-string $name   Field code, e.g. 'timestampX'
+     * @param string[]         $select Fields to return. Available: name, type, title, description,
+     *                                 validationRules, requiredGroups, filterable, sortable,
+     *                                 editable, multiple, elementType
+     *
+     * @throws BaseException
+     * @throws TransportException
+     */
+    #[ApiEndpointMetadata(
+        'main.eventlog.field.get',
+        'https://apidocs.bitrix24.ru/api-reference/rest-v3/main/main-eventlog-field-get.html',
+        'Get metadata for a single event log field by name',
+        ApiVersion::v3
+    )]
+    public function get(string $name, array $select = []): EventLogFieldResult
+    {
+        $this->guardNonEmptyString($name, 'field name must not be empty');
+
+        $params = ['name' => $name];
+        if ($select !== []) {
+            $params['select'] = $select;
+        }
+
+        return new EventLogFieldResult(
+            $this->core->call('main.eventlog.field.get', $params, ApiVersion::v3)
+        );
+    }
+
+    /**
+     * Get list of all available event log field descriptors.
+     *
+     * @link https://apidocs.bitrix24.ru/api-reference/rest-v3/main/main-eventlog-field-list.html
+     *
+     * @param string[] $select Fields to return. Available: name, type, title, description,
+     *                         validationRules, requiredGroups, filterable, sortable,
+     *                         editable, multiple, elementType
+     *
+     * @throws BaseException
+     * @throws TransportException
+     */
+    #[ApiEndpointMetadata(
+        'main.eventlog.field.list',
+        'https://apidocs.bitrix24.ru/api-reference/rest-v3/main/main-eventlog-field-list.html',
+        'Get list of all available event log field descriptors',
+        ApiVersion::v3
+    )]
+    public function list(array $select = []): EventLogFieldsResult
+    {
+        $params = $select !== [] ? ['select' => $select] : [];
+
+        return new EventLogFieldsResult(
+            $this->core->call('main.eventlog.field.list', $params, ApiVersion::v3)
+        );
+    }
+}

--- a/src/Services/Main/MainServiceBuilder.php
+++ b/src/Services/Main/MainServiceBuilder.php
@@ -16,6 +16,7 @@ namespace Bitrix24\SDK\Services\Main;
 use Bitrix24\SDK\Attributes\ApiServiceBuilderMetadata;
 use Bitrix24\SDK\Core\Credentials\Scope;
 use Bitrix24\SDK\Services\AbstractServiceBuilder;
+use Bitrix24\SDK\Services\Main\EventLogField\Service\EventLogField;
 use Bitrix24\SDK\Services\Main\Service\Documentation;
 use Bitrix24\SDK\Services\Main\Service\EventLog;
 use Bitrix24\SDK\Services\Main\Service\EventManager;
@@ -57,6 +58,15 @@ class MainServiceBuilder extends AbstractServiceBuilder
     {
         if (!isset($this->serviceCache[__METHOD__])) {
             $this->serviceCache[__METHOD__] = new EventLog($this->core, $this->log);
+        }
+
+        return $this->serviceCache[__METHOD__];
+    }
+
+    public function eventLogField(): EventLogField
+    {
+        if (!isset($this->serviceCache[__METHOD__])) {
+            $this->serviceCache[__METHOD__] = new EventLogField($this->core, $this->log);
         }
 
         return $this->serviceCache[__METHOD__];

--- a/tests/Integration/Services/Main/EventLogField/Result/EventLogFieldItemResultTest.php
+++ b/tests/Integration/Services/Main/EventLogField/Result/EventLogFieldItemResultTest.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * This file is part of the bitrix24-php-sdk package.
+ *
+ * © Maksim Mesilov <mesilov.maxim@gmail.com>
+ *
+ * For the full copyright and license information, please view the MIT-LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Bitrix24\SDK\Tests\Integration\Services\Main\EventLogField\Result;
+
+use Bitrix24\SDK\Services\Main\EventLogField\Result\EventLogFieldItemResult;
+use Bitrix24\SDK\Services\Main\EventLogField\Service\EventLogField;
+use Bitrix24\SDK\Tests\CustomAssertions\CustomBitrix24Assertions;
+use Bitrix24\SDK\Tests\Integration\Factory;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\TestDox;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(EventLogFieldItemResult::class)]
+class EventLogFieldItemResultTest extends TestCase
+{
+    use CustomBitrix24Assertions;
+
+    private EventLogField $eventLogFieldService;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        $this->eventLogFieldService = Factory::getServiceBuilder()->getMainScope()->eventLogField();
+    }
+
+    #[Test]
+    #[TestDox('all fields in EventLogFieldItemResult are annotated in phpdoc and match with raw api response')]
+    public function testAllFieldsAreAnnotated(): void
+    {
+        $allFields = $this->eventLogFieldService->get('timestampX')
+            ->getCoreResponse()->getResponseData()->getResult()['item'];
+        $this->assertBitrix24AllResultItemFieldsAnnotated(array_keys($allFields), EventLogFieldItemResult::class);
+    }
+
+    #[Test]
+    #[TestDox('all fields in EventLogFieldItemResult have valid type casting in magic getters')]
+    public function testAllFieldsHasValidTypeCastingInMagicGetters(): void
+    {
+        $eventLogFieldItemResult = $this->eventLogFieldService->get('timestampX')->eventLogField();
+        $this->assertBitrix24ResultItemFieldsTypeCastMatchAnnotations(
+            $eventLogFieldItemResult,
+            EventLogFieldItemResult::class
+        );
+    }
+}

--- a/tests/Integration/Services/Main/EventLogField/Service/EventLogFieldTest.php
+++ b/tests/Integration/Services/Main/EventLogField/Service/EventLogFieldTest.php
@@ -45,10 +45,10 @@ class EventLogFieldTest extends TestCase
     #[Test]
     public function testGet(): void
     {
-        $field = $this->service->get('timestampX')->eventLogField();
-        $this->assertNotEmpty($field->name);
-        $this->assertNotEmpty($field->type);
-        $this->assertNotEmpty($field->title);
+        $eventLogFieldItemResult = $this->service->get('timestampX')->eventLogField();
+        $this->assertNotEmpty($eventLogFieldItemResult->name);
+        $this->assertNotEmpty($eventLogFieldItemResult->type);
+        $this->assertNotEmpty($eventLogFieldItemResult->title);
     }
 
     #[Test]

--- a/tests/Integration/Services/Main/EventLogField/Service/EventLogFieldTest.php
+++ b/tests/Integration/Services/Main/EventLogField/Service/EventLogFieldTest.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * This file is part of the bitrix24-php-sdk package.
+ *
+ * © Maksim Mesilov <mesilov.maxim@gmail.com>
+ *
+ * For the full copyright and license information, please view the MIT-LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Bitrix24\SDK\Tests\Integration\Services\Main\EventLogField\Service;
+
+use Bitrix24\SDK\Services\Main\EventLogField\Result\EventLogFieldItemResult;
+use Bitrix24\SDK\Services\Main\EventLogField\Service\EventLogField;
+use Bitrix24\SDK\Tests\CustomAssertions\CustomBitrix24Assertions;
+use Bitrix24\SDK\Tests\Integration\Factory;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(EventLogField::class)]
+class EventLogFieldTest extends TestCase
+{
+    use CustomBitrix24Assertions;
+
+    private EventLogField $service;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        $this->service = Factory::getServiceBuilder()->getMainScope()->eventLogField();
+    }
+
+    #[Test]
+    public function testList(): void
+    {
+        $fields = $this->service->list()->getEventLogFields();
+        $this->assertIsArray($fields);
+        $this->assertNotEmpty($fields);
+    }
+
+    #[Test]
+    public function testGet(): void
+    {
+        $field = $this->service->get('timestampX')->eventLogField();
+        $this->assertNotEmpty($field->name);
+        $this->assertNotEmpty($field->type);
+        $this->assertNotEmpty($field->title);
+    }
+
+    #[Test]
+    public function testAllFieldsAnnotated(): void
+    {
+        $rawItems = $this->service->list()->getCoreResponse()->getResponseData()->getResult()['items'];
+        $this->assertNotEmpty($rawItems);
+        $this->assertBitrix24AllResultItemFieldsAnnotated(array_keys($rawItems[0]), EventLogFieldItemResult::class);
+    }
+}

--- a/tests/Unit/Services/Main/EventLogField/Service/EventLogFieldTest.php
+++ b/tests/Unit/Services/Main/EventLogField/Service/EventLogFieldTest.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * This file is part of the bitrix24-php-sdk package.
+ *
+ * © Maksim Mesilov <mesilov.maxim@gmail.com>
+ *
+ * For the full copyright and license information, please view the MIT-LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Bitrix24\SDK\Tests\Unit\Services\Main\EventLogField\Service;
+
+use Bitrix24\SDK\Core\Exceptions\InvalidArgumentException;
+use Bitrix24\SDK\Services\Main\EventLogField\Result\EventLogFieldResult;
+use Bitrix24\SDK\Services\Main\EventLogField\Result\EventLogFieldsResult;
+use Bitrix24\SDK\Services\Main\EventLogField\Service\EventLogField;
+use Bitrix24\SDK\Tests\Unit\Stubs\NullCore;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+#[CoversClass(EventLogField::class)]
+class EventLogFieldTest extends TestCase
+{
+    private EventLogField $service;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        $this->service = new EventLogField(new NullCore(), new NullLogger());
+    }
+
+    #[Test]
+    public function testGetReturnsEventLogFieldResult(): void
+    {
+        $this->assertInstanceOf(
+            EventLogFieldResult::class,
+            $this->service->get('timestampX')
+        );
+    }
+
+    #[Test]
+    public function testListReturnsEventLogFieldsResult(): void
+    {
+        $this->assertInstanceOf(
+            EventLogFieldsResult::class,
+            $this->service->list()
+        );
+    }
+
+    #[Test]
+    public function testGetThrowsOnEmptyName(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        /** @phpstan-ignore argument.type */
+        $this->service->get('');
+    }
+}


### PR DESCRIPTION
| Q             | A                                                                                                                         |
|---------------|---------------------------------------------------------------------------------------------------------------------------|
| Bug fix?      | no                                                                                                                        |
| New feature?  | yes                                                                                                                       |
| Deprecations? | no                                                                                                                        |
| Issues        | Fix #394                                                                                                                  |
| License       | **MIT**                                                                                                                   |

Adds `EventLogField` service wrapping `main.eventlog.field.get` and `main.eventlog.field.list` REST API v3 endpoints. The service follows the same pattern as `ChatMessageField` in the Task scope.

Usage example:

```php
$serviceBuilder->getMainScope()->eventLogField()->list();
$serviceBuilder->getMainScope()->eventLogField()->get('timestampX');
```

## Test plan

- [x] `make lint-cs-fixer` — passed
- [x] `make lint-rector` — passed
- [x] `make lint-phpstan` — passed
- [x] `make lint-deptrac` — passed
- [x] `make test-unit` — passed (650 tests)
- [ ] `make test-integration-main-eventlog` — 4/9 pass (existing `EventLog` tests); 5 new `EventLogField` tests return HTTP 500 — `main.eventlog.field.*` not yet available on the test portal

Closes #394

🤖 Generated with [Claude Code](https://claude.ai/claude-code)