### PR TITLE
Add oauthServerUrl field to LocalAppAuth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### Added
 
+- Added `oauthServerUrl` field to `LocalAppAuth`: stored in `toArray()` as `oauth_server_url`, restored in `initFromArray()` with fallback to `DefaultOAuthServerUrl::default()` for backward compatibility ([#385](https://github.com/bitrix24/b24phpsdk/issues/385))
 - Added `TaskField` service for `tasks.task.field.get` and `tasks.task.field.list` support ([#395](https://github.com/bitrix24/b24phpsdk/issues/395))
 - Added project-level GitHub MCP server configuration (`.mcp.json`) for AI-assisted development with Claude Code
 - Added Claude Code skill `.claude/skills/b24phpsdk-maintainer/SKILL.md` for repository maintainers — enforces conventions when working with GitHub issues

--- a/src/Application/Local/Entity/LocalAppAuth.php
+++ b/src/Application/Local/Entity/LocalAppAuth.php
@@ -14,13 +14,15 @@ declare(strict_types=1);
 namespace Bitrix24\SDK\Application\Local\Entity;
 
 use Bitrix24\SDK\Core\Credentials\AuthToken;
+use Bitrix24\SDK\Core\Credentials\DefaultOAuthServerUrl;
 
 final class LocalAppAuth
 {
     public function __construct(
-        private AuthToken       $authToken,
-        private readonly string $domainUrl,
-        private readonly ?string         $applicationToken)
+        private AuthToken        $authToken,
+        private readonly string  $domainUrl,
+        private readonly ?string $applicationToken,
+        private readonly string  $oauthServerUrl)
     {
     }
 
@@ -44,12 +46,18 @@ final class LocalAppAuth
         return $this->applicationToken;
     }
 
+    public function getOAuthServerUrl(): string
+    {
+        return $this->oauthServerUrl;
+    }
+
     public static function initFromArray(array $localAppAuthPayload): self
     {
         return new self(
             AuthToken::initFromArray($localAppAuthPayload['auth_token']),
             $localAppAuthPayload['domain_url'],
-            $localAppAuthPayload['application_token']);
+            $localAppAuthPayload['application_token'],
+            $localAppAuthPayload['oauth_server_url'] ?? DefaultOAuthServerUrl::default());
     }
 
     public function toArray(): array
@@ -62,6 +70,7 @@ final class LocalAppAuth
             ],
             'domain_url' => $this->domainUrl,
             'application_token' => $this->applicationToken,
+            'oauth_server_url' => $this->oauthServerUrl,
         ];
     }
 }

--- a/tests/Unit/Application/Local/Entity/LocalAppAuthTest.php
+++ b/tests/Unit/Application/Local/Entity/LocalAppAuthTest.php
@@ -1,0 +1,138 @@
+<?php
+
+/**
+ * This file is part of the bitrix24-php-sdk package.
+ *
+ * © Maksim Mesilov <mesilov.maxim@gmail.com>
+ *
+ * For the full copyright and license information, please view the MIT-LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Bitrix24\SDK\Tests\Unit\Application\Local\Entity;
+
+use Bitrix24\SDK\Application\Local\Entity\LocalAppAuth;
+use Bitrix24\SDK\Core\Credentials\AuthToken;
+use Bitrix24\SDK\Core\Credentials\DefaultOAuthServerUrl;
+use Generator;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(LocalAppAuth::class)]
+class LocalAppAuthTest extends TestCase
+{
+    private const string DOMAIN_URL = 'https://example.bitrix24.com';
+
+    private const string APPLICATION_TOKEN = 'app_token_123';
+
+    private const string OAUTH_SERVER_URL = 'https://oauth.bitrix24.tech/';
+
+    private function makeAuthToken(): AuthToken
+    {
+        return new AuthToken('access_token_abc', 'refresh_token_xyz', 9999999999);
+    }
+
+    private function makePayload(?string $oauthServerUrl = self::OAUTH_SERVER_URL): array
+    {
+        $payload = [
+            'auth_token' => [
+                'access_token' => 'access_token_abc',
+                'refresh_token' => 'refresh_token_xyz',
+                'expires' => 9999999999,
+            ],
+            'domain_url' => self::DOMAIN_URL,
+            'application_token' => self::APPLICATION_TOKEN,
+        ];
+
+        if ($oauthServerUrl !== null) {
+            $payload['oauth_server_url'] = $oauthServerUrl;
+        }
+
+        return $payload;
+    }
+
+    #[Test]
+    public function testGetOAuthServerUrlReturnsValuePassedToConstructor(): void
+    {
+        $localAppAuth = new LocalAppAuth(
+            $this->makeAuthToken(),
+            self::DOMAIN_URL,
+            self::APPLICATION_TOKEN,
+            self::OAUTH_SERVER_URL
+        );
+
+        $this->assertSame(self::OAUTH_SERVER_URL, $localAppAuth->getOAuthServerUrl());
+    }
+
+    #[Test]
+    public function testToArrayIncludesOauthServerUrl(): void
+    {
+        $localAppAuth = new LocalAppAuth(
+            $this->makeAuthToken(),
+            self::DOMAIN_URL,
+            self::APPLICATION_TOKEN,
+            self::OAUTH_SERVER_URL
+        );
+
+        $data = $localAppAuth->toArray();
+
+        $this->assertArrayHasKey('oauth_server_url', $data);
+        $this->assertSame(self::OAUTH_SERVER_URL, $data['oauth_server_url']);
+    }
+
+    #[Test]
+    public function testInitFromArrayRestoresOauthServerUrl(): void
+    {
+        $localAppAuth = LocalAppAuth::initFromArray($this->makePayload(self::OAUTH_SERVER_URL));
+
+        $this->assertSame(self::OAUTH_SERVER_URL, $localAppAuth->getOAuthServerUrl());
+    }
+
+    #[Test]
+    public function testInitFromArrayFallsBackToDefaultWhenOauthServerUrlAbsent(): void
+    {
+        $localAppAuth = LocalAppAuth::initFromArray($this->makePayload(null));
+
+        $this->assertSame(DefaultOAuthServerUrl::default(), $localAppAuth->getOAuthServerUrl());
+    }
+
+    #[Test]
+    public function testRoundTripPreservesAllFields(): void
+    {
+        $localAppAuth = new LocalAppAuth(
+            $this->makeAuthToken(),
+            self::DOMAIN_URL,
+            self::APPLICATION_TOKEN,
+            self::OAUTH_SERVER_URL
+        );
+
+        $restored = LocalAppAuth::initFromArray($localAppAuth->toArray());
+
+        $this->assertSame($localAppAuth->getDomainUrl(), $restored->getDomainUrl());
+        $this->assertSame($localAppAuth->getApplicationToken(), $restored->getApplicationToken());
+        $this->assertSame($localAppAuth->getOAuthServerUrl(), $restored->getOAuthServerUrl());
+        $this->assertSame($localAppAuth->getAuthToken()->accessToken, $restored->getAuthToken()->accessToken);
+        $this->assertSame($localAppAuth->getAuthToken()->refreshToken, $restored->getAuthToken()->refreshToken);
+        $this->assertSame($localAppAuth->getAuthToken()->expires, $restored->getAuthToken()->expires);
+    }
+
+    #[Test]
+    #[DataProvider('oauthServerUrlVariantsProvider')]
+    public function testInitFromArrayWithDifferentOauthServerUrls(string $url): void
+    {
+        $localAppAuth = LocalAppAuth::initFromArray($this->makePayload($url));
+
+        $this->assertSame($url, $localAppAuth->getOAuthServerUrl());
+    }
+
+    public static function oauthServerUrlVariantsProvider(): Generator
+    {
+        yield 'east region' => [DefaultOAuthServerUrl::east()];
+        yield 'west region' => [DefaultOAuthServerUrl::west()];
+        yield 'custom server' => ['https://oauth.my-custom-server.com/'];
+    }
+}


### PR DESCRIPTION
| Q             | A                                                                                                                         |
|---------------|---------------------------------------------------------------------------------------------------------------------------|
| Bug fix?      | no                                                                                                                        |
| New feature?  | yes                                                                                                                       |
| Deprecations? | no                                                                                                                        |
| Issues        | Fix #385                                                                                                                  |
| License       | **MIT**                                                                                                                   |

`LocalAppAuth` stores authentication data for local apps. When a Bitrix24 event or placement request
arrives, the raw auth payload contains `server_endpoint` — the OAuth server URL that issued the token
(e.g. `oauth.bitrix24.tech` for east, `oauth.bitrix.info` for west).

Previously `LocalAppAuth` did not store this URL, so any consumer reconstructing `Credentials`
from a saved `LocalAppAuth` had to hard-code or guess the OAuth server via `DefaultOAuthServerUrl::default()`,
which breaks multi-region deployments.

**Changes:**
- Added `oauthServerUrl: string` constructor parameter to `LocalAppAuth`
- Added `getOAuthServerUrl(): string` getter
- `toArray()` serialises it as `oauth_server_url`
- `initFromArray()` reads `oauth_server_url` with a fallback to `DefaultOAuthServerUrl::default()` for backward compatibility with files written by older SDK versions
- Added unit tests covering constructor, getter, round-trip, backward-compat fallback, and data-provider variants (east / west / custom)

## Test plan

- [x] `make lint-cs-fixer` — passed
- [x] `make lint-rector` — passed (auto-fix applied: variable rename by Rector)
- [x] `make lint-phpstan` — passed
- [x] `make lint-deptrac` — passed (0 violations)
- [x] `make test-unit` — passed (661 tests, 1136 assertions)

Closes #385

🤖 Generated with [Claude Code](https://claude.ai/claude-code)