### PR TITLE
Add createRepositoryFlusherImplementation to Bitrix24PartnerRepositoryInterfaceTest

### DIFF
--- a/.tasks/416/plan.md
+++ b/.tasks/416/plan.md
@@ -1,0 +1,414 @@
+# Add createRepositoryFlusherImplementation to Bitrix24PartnerRepositoryInterfaceTest Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Bring `Bitrix24PartnerRepositoryInterfaceTest` in line with all other repository contract tests by adding the `createRepositoryFlusherImplementation()` abstract method and calling `$flusher->flush()` after every `save()` / `delete()` operation.
+
+**Architecture:** Single-file change in the test infrastructure layer. No production code is modified. The pattern mirrors `Bitrix24AccountRepositoryInterfaceTest` exactly: each test obtains a flusher instance and calls `flush()` after every write to ensure implementations backed by Doctrine ORM (or any unit-of-work storage) are exercised correctly.
+
+**Tech Stack:** PHP 8.2, PHPUnit 11, `TestRepositoryFlusherInterface` (already exists at `tests/Application/Contracts/TestRepositoryFlusherInterface.php`)
+
+**Design doc:** `docs/plans/2026-04-15-partner-repository-flusher-design.md`
+
+---
+
+### Task 1: Add import and abstract method declaration
+
+**Files:**
+- Modify: `tests/Application/Contracts/Bitrix24Partners/Repository/Bitrix24PartnerRepositoryInterfaceTest.php:22`
+
+**Step 1: Add the missing import**
+
+In the `use` block (after line 21 `use Bitrix24\SDK\Core\Exceptions\InvalidArgumentException;`), add:
+
+```php
+use Bitrix24\SDK\Tests\Application\Contracts\TestRepositoryFlusherInterface;
+```
+
+**Step 2: Add the abstract method**
+
+After the existing `createBitrix24PartnerRepositoryImplementation()` declaration (line 49), add:
+
+```php
+abstract protected function createRepositoryFlusherImplementation(): TestRepositoryFlusherInterface;
+```
+
+**Step 3: Verify with static analysis**
+
+```bash
+make lint-phpstan
+```
+
+Expected: no new errors related to this file.
+
+**Step 4: Commit**
+
+```bash
+git add tests/Application/Contracts/Bitrix24Partners/Repository/Bitrix24PartnerRepositoryInterfaceTest.php
+git commit -m "Add createRepositoryFlusherImplementation to Bitrix24PartnerRepositoryInterfaceTest (#416)"
+```
+
+---
+
+### Task 2: Update testSave
+
+**Files:**
+- Modify: `tests/Application/Contracts/Bitrix24Partners/Repository/Bitrix24PartnerRepositoryInterfaceTest.php:55-80`
+
+**Step 1: Update the test body**
+
+Locate `testSave`. The current body is:
+
+```php
+$b24Partner = $this->createBitrix24PartnerImplementation($uuid, $createdAt, $updatedAt, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId);
+$b24PartnerRepository = $this->createBitrix24PartnerRepositoryImplementation();
+
+$b24PartnerRepository->save($b24Partner);
+
+$res = $b24PartnerRepository->getById($b24Partner->getId());
+$this->assertEquals($b24Partner, $res);
+```
+
+Replace with:
+
+```php
+$b24Partner = $this->createBitrix24PartnerImplementation($uuid, $createdAt, $updatedAt, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId);
+$b24PartnerRepository = $this->createBitrix24PartnerRepositoryImplementation();
+$flusher = $this->createRepositoryFlusherImplementation();
+
+$b24PartnerRepository->save($b24Partner);
+$flusher->flush();
+
+$res = $b24PartnerRepository->getById($b24Partner->getId());
+$this->assertEquals($b24Partner, $res);
+```
+
+**Step 2: Run unit tests**
+
+```bash
+make test-unit
+```
+
+Expected: all tests pass.
+
+---
+
+### Task 3: Update testSaveWithTwoBitrix24PartnerNumber
+
+**Files:**
+- Modify: `tests/Application/Contracts/Bitrix24Partners/Repository/Bitrix24PartnerRepositoryInterfaceTest.php:85-115`
+
+**Step 1: Update the test body**
+
+Locate `testSaveWithTwoBitrix24PartnerNumber`. Current body:
+
+```php
+$b24Partner = $this->createBitrix24PartnerImplementation($uuid, $createdAt, $updatedAt, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId);
+$b24PartnerRepository = $this->createBitrix24PartnerRepositoryImplementation();
+
+$b24PartnerRepository->save($b24Partner);
+
+$res = $b24PartnerRepository->getById($b24Partner->getId());
+$this->assertEquals($b24Partner, $res);
+
+$secondB24Partner = $this->createBitrix24PartnerImplementation(Uuid::v7(), $createdAt, $updatedAt, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId);
+$this->expectException(InvalidArgumentException::class);
+$b24PartnerRepository->save($secondB24Partner);
+```
+
+Replace with:
+
+```php
+$b24Partner = $this->createBitrix24PartnerImplementation($uuid, $createdAt, $updatedAt, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId);
+$b24PartnerRepository = $this->createBitrix24PartnerRepositoryImplementation();
+$flusher = $this->createRepositoryFlusherImplementation();
+
+$b24PartnerRepository->save($b24Partner);
+$flusher->flush();
+
+$res = $b24PartnerRepository->getById($b24Partner->getId());
+$this->assertEquals($b24Partner, $res);
+
+$secondB24Partner = $this->createBitrix24PartnerImplementation(Uuid::v7(), $createdAt, $updatedAt, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId);
+$this->expectException(InvalidArgumentException::class);
+$b24PartnerRepository->save($secondB24Partner);
+```
+
+**Step 2: Run unit tests**
+
+```bash
+make test-unit
+```
+
+Expected: all tests pass.
+
+---
+
+### Task 4: Update testDelete
+
+**Files:**
+- Modify: `tests/Application/Contracts/Bitrix24Partners/Repository/Bitrix24PartnerRepositoryInterfaceTest.php:120-148`
+
+**Step 1: Update the test body**
+
+Locate `testDelete`. Current body:
+
+```php
+$b24Partner = $this->createBitrix24PartnerImplementation($uuid, $createdAt, $updatedAt, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId);
+$b24PartnerRepository = $this->createBitrix24PartnerRepositoryImplementation();
+
+$b24Partner->markAsDeleted('delete partner');
+$b24PartnerRepository->save($b24Partner);
+
+$b24PartnerRepository->delete($b24Partner->getId());
+
+$this->assertNull($b24PartnerRepository->findByBitrix24PartnerNumber($bitrix24PartnerNumber));
+```
+
+Replace with:
+
+```php
+$b24Partner = $this->createBitrix24PartnerImplementation($uuid, $createdAt, $updatedAt, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId);
+$b24PartnerRepository = $this->createBitrix24PartnerRepositoryImplementation();
+$flusher = $this->createRepositoryFlusherImplementation();
+
+$b24Partner->markAsDeleted('delete partner');
+$b24PartnerRepository->save($b24Partner);
+$flusher->flush();
+
+$b24PartnerRepository->delete($b24Partner->getId());
+$flusher->flush();
+
+$this->assertNull($b24PartnerRepository->findByBitrix24PartnerNumber($bitrix24PartnerNumber));
+```
+
+**Step 2: Run unit tests**
+
+```bash
+make test-unit
+```
+
+Expected: all tests pass.
+
+---
+
+### Task 5: Update testGetById
+
+**Files:**
+- Modify: `tests/Application/Contracts/Bitrix24Partners/Repository/Bitrix24PartnerRepositoryInterfaceTest.php:153-182`
+
+**Step 1: Update the test body**
+
+Locate `testGetById`. Current body:
+
+```php
+$b24Partner = $this->createBitrix24PartnerImplementation($uuid, $createdAt, $updatedAt, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId);
+$b24PartnerRepository = $this->createBitrix24PartnerRepositoryImplementation();
+
+$b24PartnerRepository->save($b24Partner);
+
+$res = $b24PartnerRepository->getById($b24Partner->getId());
+$this->assertEquals($b24Partner, $res);
+
+$this->expectException(Bitrix24PartnerNotFoundException::class);
+$b24PartnerRepository->getById(Uuid::v7());
+```
+
+Replace with:
+
+```php
+$b24Partner = $this->createBitrix24PartnerImplementation($uuid, $createdAt, $updatedAt, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId);
+$b24PartnerRepository = $this->createBitrix24PartnerRepositoryImplementation();
+$flusher = $this->createRepositoryFlusherImplementation();
+
+$b24PartnerRepository->save($b24Partner);
+$flusher->flush();
+
+$res = $b24PartnerRepository->getById($b24Partner->getId());
+$this->assertEquals($b24Partner, $res);
+
+$this->expectException(Bitrix24PartnerNotFoundException::class);
+$b24PartnerRepository->getById(Uuid::v7());
+```
+
+**Step 2: Run unit tests**
+
+```bash
+make test-unit
+```
+
+Expected: all tests pass.
+
+---
+
+### Task 6: Update testFindByBitrix24PartnerNumber
+
+**Files:**
+- Modify: `tests/Application/Contracts/Bitrix24Partners/Repository/Bitrix24PartnerRepositoryInterfaceTest.php:186-215`
+
+**Step 1: Update the test body**
+
+Locate `testFindByBitrix24PartnerNumber`. Current body:
+
+```php
+$b24Partner = $this->createBitrix24PartnerImplementation($uuid, $createdAt, $updatedAt, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId);
+$b24PartnerRepository = $this->createBitrix24PartnerRepositoryImplementation();
+
+$b24PartnerRepository->save($b24Partner);
+
+$res = $b24PartnerRepository->findByBitrix24PartnerNumber($b24Partner->getBitrix24PartnerNumber());
+$this->assertEquals($b24Partner, $res);
+
+
+$this->assertNull($b24PartnerRepository->findByBitrix24PartnerNumber(0));
+```
+
+Replace with:
+
+```php
+$b24Partner = $this->createBitrix24PartnerImplementation($uuid, $createdAt, $updatedAt, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId);
+$b24PartnerRepository = $this->createBitrix24PartnerRepositoryImplementation();
+$flusher = $this->createRepositoryFlusherImplementation();
+
+$b24PartnerRepository->save($b24Partner);
+$flusher->flush();
+
+$res = $b24PartnerRepository->findByBitrix24PartnerNumber($b24Partner->getBitrix24PartnerNumber());
+$this->assertEquals($b24Partner, $res);
+
+$this->assertNull($b24PartnerRepository->findByBitrix24PartnerNumber(0));
+```
+
+**Step 2: Run unit tests**
+
+```bash
+make test-unit
+```
+
+Expected: all tests pass.
+
+---
+
+### Task 7: Update testFindByTitle
+
+**Files:**
+- Modify: `tests/Application/Contracts/Bitrix24Partners/Repository/Bitrix24PartnerRepositoryInterfaceTest.php:217-244`
+
+**Step 1: Update the test body**
+
+Locate `testFindByTitle`. Current body:
+
+```php
+$b24Partner = $this->createBitrix24PartnerImplementation($uuid, $createdAt, $updatedAt, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId);
+$b24PartnerRepository = $this->createBitrix24PartnerRepositoryImplementation();
+
+$b24PartnerRepository->save($b24Partner);
+
+$res = $b24PartnerRepository->findByTitle($b24Partner->getTitle());
+$this->assertEquals($b24Partner, $res[0]);
+
+$this->assertEmpty($b24PartnerRepository->findByTitle('test'));
+```
+
+Replace with:
+
+```php
+$b24Partner = $this->createBitrix24PartnerImplementation($uuid, $createdAt, $updatedAt, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId);
+$b24PartnerRepository = $this->createBitrix24PartnerRepositoryImplementation();
+$flusher = $this->createRepositoryFlusherImplementation();
+
+$b24PartnerRepository->save($b24Partner);
+$flusher->flush();
+
+$res = $b24PartnerRepository->findByTitle($b24Partner->getTitle());
+$this->assertEquals($b24Partner, $res[0]);
+
+$this->assertEmpty($b24PartnerRepository->findByTitle('test'));
+```
+
+**Step 2: Run unit tests**
+
+```bash
+make test-unit
+```
+
+Expected: all tests pass.
+
+---
+
+### Task 8: Update testFindByExternalId
+
+**Files:**
+- Modify: `tests/Application/Contracts/Bitrix24Partners/Repository/Bitrix24PartnerRepositoryInterfaceTest.php:247-273`
+
+**Step 1: Update the test body**
+
+Locate `testFindByExternalId`. Current body:
+
+```php
+$b24Partner = $this->createBitrix24PartnerImplementation($uuid, $createdAt, $updatedAt, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId);
+$b24PartnerRepository = $this->createBitrix24PartnerRepositoryImplementation();
+
+$b24PartnerRepository->save($b24Partner);
+
+$res = $b24PartnerRepository->findByExternalId($b24Partner->getExternalId());
+$this->assertEquals($b24Partner, $res[0]);
+
+$this->assertEmpty($b24PartnerRepository->findByExternalId('test'));
+```
+
+Replace with:
+
+```php
+$b24Partner = $this->createBitrix24PartnerImplementation($uuid, $createdAt, $updatedAt, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId);
+$b24PartnerRepository = $this->createBitrix24PartnerRepositoryImplementation();
+$flusher = $this->createRepositoryFlusherImplementation();
+
+$b24PartnerRepository->save($b24Partner);
+$flusher->flush();
+
+$res = $b24PartnerRepository->findByExternalId($b24Partner->getExternalId());
+$this->assertEquals($b24Partner, $res[0]);
+
+$this->assertEmpty($b24PartnerRepository->findByExternalId('test'));
+```
+
+**Step 2: Run unit tests**
+
+```bash
+make test-unit
+```
+
+Expected: all tests pass.
+
+---
+
+### Task 9: Quality gate + CHANGELOG + final commit
+
+**Step 1: Run full quality gate (Phase 1)**
+
+```bash
+make lint-cs-fixer
+make lint-rector
+make lint-phpstan
+make lint-deptrac
+make test-unit
+```
+
+Expected: all pass with zero errors.
+
+**Step 2: Update CHANGELOG.md**
+
+Open `CHANGELOG.md`. Under `## X.Y.Z Unreleased` → `### Changed` (add section if missing), add:
+
+```markdown
+### Changed
+- Add `createRepositoryFlusherImplementation()` to `Bitrix24PartnerRepositoryInterfaceTest` and update tests to call `flush()` after every write operation ([#416](https://github.com/bitrix24/b24phpsdk/issues/416))
+```
+
+**Step 3: Commit everything**
+
+```bash
+git add tests/Application/Contracts/Bitrix24Partners/Repository/Bitrix24PartnerRepositoryInterfaceTest.php CHANGELOG.md
+git commit -m "Add flusher support to Bitrix24PartnerRepositoryInterfaceTest (#416)"
+```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 
 ### Changed
 
+- Added `createRepositoryFlusherImplementation()` abstract method to `Bitrix24PartnerRepositoryInterfaceTest` and updated all 7 test methods to call `flush()` after every write operation, aligning with the contract test pattern used by `Bitrix24AccountRepositoryInterfaceTest` and `ApplicationInstallationRepositoryInterfaceTest` ([#416](https://github.com/bitrix24/b24phpsdk/issues/416))
 - `ContactPersonInterface::getBitrix24UserId()` now returns `int` instead of `?int` — a ContactPerson is always linked to a Bitrix24 user ([#365](https://github.com/bitrix24/b24phpsdk/issues/365))
 - Updated `.claude/skills/b24phpsdk-maintainer/SKILL.md`: added `make lint-rector` to Phase 1 quality gate and PR test plan checklist to prevent missed Rector violations in CI
 - Updated `.claude/skills/b24phpsdk-maintainer/SKILL.md`: PR body must now be built from `.github/PULL_REQUEST_TEMPLATE.md` instead of a hardcoded template

--- a/docs/plans/2026-04-15-partner-repository-flusher-design.md
+++ b/docs/plans/2026-04-15-partner-repository-flusher-design.md
@@ -1,0 +1,73 @@
+# Design: Add createRepositoryFlusherImplementation to Bitrix24PartnerRepositoryInterfaceTest (issue #416)
+
+## Context
+
+`Bitrix24PartnerRepositoryInterfaceTest` is an abstract contract test class that SDK consumers
+extend to verify their implementations of `Bitrix24PartnerRepositoryInterface`. All other
+repository contract tests (`Bitrix24AccountRepositoryInterfaceTest`,
+`ApplicationInstallationRepositoryInterfaceTest`, `ContactPersonRepositoryInterfaceTest`) already
+declare an abstract `createRepositoryFlusherImplementation(): TestRepositoryFlusherInterface` method
+and call `$flusher->flush()` after every `save()` / `delete()` call. `Bitrix24PartnerRepositoryInterfaceTest`
+is the only one that is missing this method, making the contract incomplete and leaving repository
+implementations that require an explicit flush (e.g., Doctrine ORM) untested.
+
+`ContactPersonRepositoryInterfaceTest` already has the flusher — no changes needed there.
+
+---
+
+## File to Modify
+
+### `tests/Application/Contracts/Bitrix24Partners/Repository/Bitrix24PartnerRepositoryInterfaceTest.php`
+
+**Change 1 — add import** (after the existing `use` block):
+
+```php
+use Bitrix24\SDK\Tests\Application\Contracts\TestRepositoryFlusherInterface;
+```
+
+**Change 2 — add abstract method** (after `createBitrix24PartnerRepositoryImplementation()`):
+
+```php
+abstract protected function createRepositoryFlusherImplementation(): TestRepositoryFlusherInterface;
+```
+
+**Change 3 — update 7 test methods** to obtain the flusher and call `flush()`:
+
+| Test method | Where to add flusher lines |
+|---|---|
+| `testSave` | obtain flusher before save; `flush()` after `save()` |
+| `testSaveWithTwoBitrix24PartnerNumber` | obtain flusher before first save; `flush()` after first `save()` |
+| `testDelete` | obtain flusher before save; `flush()` after `save()` and after `delete()` |
+| `testGetById` | obtain flusher before save; `flush()` after `save()` |
+| `testFindByBitrix24PartnerNumber` | obtain flusher before save; `flush()` after `save()` |
+| `testFindByTitle` | obtain flusher before save; `flush()` after `save()` |
+| `testFindByExternalId` | obtain flusher before save; `flush()` after `save()` |
+
+Pattern to follow (from `Bitrix24AccountRepositoryInterfaceTest`):
+
+```php
+$b24PartnerRepository = $this->createBitrix24PartnerRepositoryImplementation();
+$flusher = $this->createRepositoryFlusherImplementation();
+
+$b24PartnerRepository->save($b24Partner);
+$flusher->flush();
+```
+
+---
+
+## Deptrac Compliance
+
+Changes are confined to `tests/`. No production source files are modified.
+No new layer dependencies are introduced.
+
+---
+
+## Verification
+
+```bash
+make lint-cs-fixer
+make lint-rector
+make lint-phpstan
+make lint-deptrac
+make test-unit
+```

--- a/tests/Application/Contracts/Bitrix24Partners/Repository/Bitrix24PartnerRepositoryInterfaceTest.php
+++ b/tests/Application/Contracts/Bitrix24Partners/Repository/Bitrix24PartnerRepositoryInterfaceTest.php
@@ -75,8 +75,10 @@ abstract class Bitrix24PartnerRepositoryInterfaceTest extends TestCase
     {
         $b24Partner = $this->createBitrix24PartnerImplementation($uuid, $createdAt, $updatedAt, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId);
         $b24PartnerRepository = $this->createBitrix24PartnerRepositoryImplementation();
+        $flusher = $this->createRepositoryFlusherImplementation();
 
         $b24PartnerRepository->save($b24Partner);
+        $flusher->flush();
 
         $res = $b24PartnerRepository->getById($b24Partner->getId());
         $this->assertEquals($b24Partner, $res);
@@ -106,8 +108,10 @@ abstract class Bitrix24PartnerRepositoryInterfaceTest extends TestCase
     {
         $b24Partner = $this->createBitrix24PartnerImplementation($uuid, $createdAt, $updatedAt, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId);
         $b24PartnerRepository = $this->createBitrix24PartnerRepositoryImplementation();
+        $flusher = $this->createRepositoryFlusherImplementation();
 
         $b24PartnerRepository->save($b24Partner);
+        $flusher->flush();
 
         $res = $b24PartnerRepository->getById($b24Partner->getId());
         $this->assertEquals($b24Partner, $res);
@@ -141,11 +145,14 @@ abstract class Bitrix24PartnerRepositoryInterfaceTest extends TestCase
     {
         $b24Partner = $this->createBitrix24PartnerImplementation($uuid, $createdAt, $updatedAt, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId);
         $b24PartnerRepository = $this->createBitrix24PartnerRepositoryImplementation();
+        $flusher = $this->createRepositoryFlusherImplementation();
 
         $b24Partner->markAsDeleted('delete partner');
         $b24PartnerRepository->save($b24Partner);
+        $flusher->flush();
 
         $b24PartnerRepository->delete($b24Partner->getId());
+        $flusher->flush();
 
         $this->assertNull($b24PartnerRepository->findByBitrix24PartnerNumber($bitrix24PartnerNumber));
     }
@@ -174,8 +181,10 @@ abstract class Bitrix24PartnerRepositoryInterfaceTest extends TestCase
     {
         $b24Partner = $this->createBitrix24PartnerImplementation($uuid, $createdAt, $updatedAt, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId);
         $b24PartnerRepository = $this->createBitrix24PartnerRepositoryImplementation();
+        $flusher = $this->createRepositoryFlusherImplementation();
 
         $b24PartnerRepository->save($b24Partner);
+        $flusher->flush();
 
         $res = $b24PartnerRepository->getById($b24Partner->getId());
         $this->assertEquals($b24Partner, $res);
@@ -207,12 +216,13 @@ abstract class Bitrix24PartnerRepositoryInterfaceTest extends TestCase
     {
         $b24Partner = $this->createBitrix24PartnerImplementation($uuid, $createdAt, $updatedAt, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId);
         $b24PartnerRepository = $this->createBitrix24PartnerRepositoryImplementation();
+        $flusher = $this->createRepositoryFlusherImplementation();
 
         $b24PartnerRepository->save($b24Partner);
+        $flusher->flush();
 
         $res = $b24PartnerRepository->findByBitrix24PartnerNumber($b24Partner->getBitrix24PartnerNumber());
         $this->assertEquals($b24Partner, $res);
-
 
         $this->assertNull($b24PartnerRepository->findByBitrix24PartnerNumber(0));
     }
@@ -237,8 +247,10 @@ abstract class Bitrix24PartnerRepositoryInterfaceTest extends TestCase
     {
         $b24Partner = $this->createBitrix24PartnerImplementation($uuid, $createdAt, $updatedAt, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId);
         $b24PartnerRepository = $this->createBitrix24PartnerRepositoryImplementation();
+        $flusher = $this->createRepositoryFlusherImplementation();
 
         $b24PartnerRepository->save($b24Partner);
+        $flusher->flush();
 
         $res = $b24PartnerRepository->findByTitle($b24Partner->getTitle());
         $this->assertEquals($b24Partner, $res[0]);
@@ -266,8 +278,10 @@ abstract class Bitrix24PartnerRepositoryInterfaceTest extends TestCase
     {
         $b24Partner = $this->createBitrix24PartnerImplementation($uuid, $createdAt, $updatedAt, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId);
         $b24PartnerRepository = $this->createBitrix24PartnerRepositoryImplementation();
+        $flusher = $this->createRepositoryFlusherImplementation();
 
         $b24PartnerRepository->save($b24Partner);
+        $flusher->flush();
 
         $res = $b24PartnerRepository->findByExternalId($b24Partner->getExternalId());
         $this->assertEquals($b24Partner, $res[0]);

--- a/tests/Application/Contracts/Bitrix24Partners/Repository/Bitrix24PartnerRepositoryInterfaceTest.php
+++ b/tests/Application/Contracts/Bitrix24Partners/Repository/Bitrix24PartnerRepositoryInterfaceTest.php
@@ -18,6 +18,7 @@ use Bitrix24\SDK\Application\Contracts\Bitrix24Partners\Entity\Bitrix24PartnerSt
 use Bitrix24\SDK\Application\Contracts\Bitrix24Partners\Exceptions\Bitrix24PartnerNotFoundException;
 use Bitrix24\SDK\Application\Contracts\Bitrix24Partners\Repository\Bitrix24PartnerRepositoryInterface;
 use Bitrix24\SDK\Core\Exceptions\InvalidArgumentException;
+use Bitrix24\SDK\Tests\Application\Contracts\TestRepositoryFlusherInterface;
 use Bitrix24\SDK\Tests\Builders\DemoDataGenerator;
 use Carbon\CarbonImmutable;
 use Generator;
@@ -47,6 +48,8 @@ abstract class Bitrix24PartnerRepositoryInterfaceTest extends TestCase
         ?string               $externalId): Bitrix24PartnerInterface;
 
     abstract protected function createBitrix24PartnerRepositoryImplementation(): Bitrix24PartnerRepositoryInterface;
+
+    abstract protected function createRepositoryFlusherImplementation(): TestRepositoryFlusherInterface;
 
     /**
      * @throws InvalidArgumentException

--- a/tests/Unit/Application/Contracts/Bitrix24Partners/Repository/InMemoryBitrix24PartnerRepositoryImplementationTest.php
+++ b/tests/Unit/Application/Contracts/Bitrix24Partners/Repository/InMemoryBitrix24PartnerRepositoryImplementationTest.php
@@ -26,6 +26,8 @@ use Bitrix24\SDK\Core\Credentials\AuthToken;
 use Bitrix24\SDK\Core\Credentials\Scope;
 use Bitrix24\SDK\Tests\Application\Contracts\Bitrix24Partners\Repository\Bitrix24PartnerRepositoryInterfaceTest;
 use Bitrix24\SDK\Tests\Application\Contracts\ContactPersons\Repository\ContactPersonRepositoryInterfaceTest;
+use Bitrix24\SDK\Tests\Application\Contracts\NullableFlusher;
+use Bitrix24\SDK\Tests\Application\Contracts\TestRepositoryFlusherInterface;
 use Bitrix24\SDK\Tests\Unit\Application\Contracts\Bitrix24Accounts\Entity\Bitrix24AccountReferenceEntityImplementation;
 use Bitrix24\SDK\Tests\Unit\Application\Contracts\Bitrix24Partners\Entity\Bitrix24PartnerReferenceEntityImplementation;
 use Bitrix24\SDK\Tests\Unit\Application\Contracts\ContactPersons\Entity\ContactPersonReferenceEntityImplementation;
@@ -72,5 +74,11 @@ class InMemoryBitrix24PartnerRepositoryImplementationTest extends Bitrix24Partne
     protected function createBitrix24PartnerRepositoryImplementation(): Bitrix24PartnerRepositoryInterface
     {
         return new InMemoryBitrix24PartnerRepositoryImplementation(new NullLogger());
+    }
+
+    #[\Override]
+    protected function createRepositoryFlusherImplementation(): TestRepositoryFlusherInterface
+    {
+        return new NullableFlusher();
     }
 }


### PR DESCRIPTION
| Q             | A                                                                                                                         |
|---------------|---------------------------------------------------------------------------------------------------------------------------|
| Bug fix?      | no                                                                                                                        |
| New feature?  | no                                                                                                                        |
| Deprecations? | no                                                                                                                        |
| Issues        | Fix #416                                                                                                                  |
| License       | **MIT**                                                                                                                   |

`Bitrix24PartnerRepositoryInterfaceTest` was the only repository contract test missing the `createRepositoryFlusherImplementation(): TestRepositoryFlusherInterface` abstract method. All other contract tests (`Bitrix24AccountRepositoryInterfaceTest`, `ApplicationInstallationRepositoryInterfaceTest`, `ContactPersonRepositoryInterfaceTest`) already declare this method and call `flush()` after every write operation.

This PR adds the missing abstract method to `Bitrix24PartnerRepositoryInterfaceTest`, implements it in `InMemoryBitrix24PartnerRepositoryImplementationTest` using `NullableFlusher`, and updates all 7 test methods to call `$flusher->flush()` after every `save()` / `delete()` call — ensuring implementations backed by Doctrine ORM or any unit-of-work storage are exercised correctly.

## Test plan

- [x] `make lint-cs-fixer` — passed (0 files to fix)
- [x] `make lint-rector` — passed
- [x] `make lint-phpstan` — passed (0 errors)
- [x] `make lint-deptrac` — passed (0 violations)
- [x] `make test-unit` — passed (751 tests, 1928 assertions)

Closes #416

🤖 Generated with [Claude Code](https://claude.ai/claude-code)