### PR TITLE
Add logo URL support to Bitrix24PartnerInterface

### DIFF
--- a/.tasks/452/plan.md
+++ b/.tasks/452/plan.md
@@ -1,0 +1,93 @@
+# Plan: Add logo support to Bitrix24Partner contract (issue #452)
+
+## Context
+
+Issue #452 asks to extend the `Bitrix24PartnerInterface` (located at
+`src/Application/Contracts/Bitrix24Partners/Entity/Bitrix24PartnerInterface.php`)
+with logo URL support. The partner entity already has optional string properties
+such as `site`, `email`, and `openLineId`, all following the same getter/setter
+pattern. Logo URL is an optional string (nullable) — it may not be set on creation.
+
+Per the issue, the public API is:
+- `getLogoUrl(): ?string` — returns the current logo URL or null if not set
+- `changeLogoUrl(?string $logoUrl): void` — updates the logo URL; throws
+  `InvalidArgumentException` on empty string; accepts null to clear
+
+A corresponding domain event `Bitrix24PartnerLogoUrlChangedEvent` is created for
+consistency with the existing events directory.
+
+Target branch: `claude/fix-issue-452-PRBE2` based on `v3-dev`.
+
+---
+
+## Files to Create
+
+### 1. `src/Application/Contracts/Bitrix24Partners/Events/Bitrix24PartnerLogoUrlChangedEvent.php`
+
+```php
+class Bitrix24PartnerLogoUrlChangedEvent extends Event
+{
+    public function __construct(
+        public readonly Uuid            $bitrix24PartnerId,
+        public readonly CarbonImmutable $timestamp,
+        public readonly ?string         $previousLogoUrl,
+        public readonly ?string         $currentLogoUrl)
+    {}
+}
+```
+
+---
+
+## Files to Modify
+
+### 1. `src/Application/Contracts/Bitrix24Partners/Entity/Bitrix24PartnerInterface.php`
+
+Add after `setOpenLineId()`:
+```php
+public function getLogoUrl(): ?string;
+public function changeLogoUrl(?string $logoUrl): void;
+```
+
+### 2. `tests/Unit/Application/Contracts/Bitrix24Partners/Entity/Bitrix24PartnerReferenceEntityImplementation.php`
+
+- Add `private ?string $logoUrl` constructor parameter
+- Implement `getLogoUrl()` and `changeLogoUrl()` with empty-string validation
+
+### 3. `tests/Application/Contracts/Bitrix24Partners/Entity/Bitrix24PartnerInterfaceTest.php`
+
+- Add `?string $logoUrl` to abstract factory method signature and all test method
+  parameter lists
+- Update `bitrix24PartnerDataProvider` to include `$logoUrl`
+- Add `testGetLogoUrl` and `testChangeLogoUrl` test methods
+
+### 4. `tests/Unit/Application/Contracts/Bitrix24Partners/Entity/Bitrix24PartnerInterfaceReferenceImplementationTest.php`
+
+- Add `?string $logoUrl` parameter to `createBitrix24PartnerImplementation` override
+- Pass `$logoUrl` to the reference implementation constructor
+
+### 5. `CHANGELOG.md`
+
+Under `## 3.2.0 – UNRELEASED` → `### Added`:
+```
+- Added `getLogoUrl()` and `changeLogoUrl()` methods to `Bitrix24PartnerInterface` and reference implementation ([#452](https://github.com/bitrix24/b24phpsdk/issues/452))
+```
+
+---
+
+## Deptrac compliance
+
+All new code lives in `Application\Contracts` (Application layer) which may only depend
+on `Core`. The event class depends only on `Carbon`, `Symfony\Uid`, and
+`Symfony\Contracts\EventDispatcher` — all allowed.
+
+---
+
+## Verification
+
+```bash
+make lint-cs-fixer
+make lint-rector
+make lint-phpstan
+make lint-deptrac
+make test-unit
+```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 ### Added
 
+- Added `getLogoUrl()` and `changeLogoUrl()` methods to `Bitrix24PartnerInterface` and reference implementation with `Bitrix24PartnerLogoUrlChangedEvent` ([#452](https://github.com/bitrix24/b24phpsdk/issues/452))
 - Added typed fluent `Services\IM\Message\Attach` payload builders for `ATTACH` blocks in `im.message.add` and `im.message.update`, plus `RawAttach::fromArray()` as an object-based escape hatch for unsupported or vendor-extended payload shapes ([#426](https://github.com/bitrix24/b24phpsdk/issues/426))
 - Added `Bitrix24\SDK\Services\IM\Placements\PlacementLocationCodes` with constants `IM_TEXTAREA`, `IM_SIDEBAR`, `IM_CONTEXT_MENU`, `IM_NAVIGATION`, and `IM_SMILES_SELECTOR` (deprecated since `im 25.1600.0`) for IM widget placement codes ([#437](https://github.com/bitrix24/b24phpsdk/issues/437))
 - Added `PlacementOptionsInterface` and fluent option builders `TextareaPlacementOptions`, `SidebarPlacementOptions`, `ContextMenuPlacementOptions` under `Bitrix24\SDK\Services\IM\Placements` namespace, backed by `ChatContext`, `PlacementColor` (IM-specific) and shared `Role`, `ExtranetAvailability` string-backed enums under `Bitrix24\SDK\Services\Placement` ([#437](https://github.com/bitrix24/b24phpsdk/issues/437))

--- a/src/Application/Contracts/Bitrix24Partners/Entity/Bitrix24PartnerInterface.php
+++ b/src/Application/Contracts/Bitrix24Partners/Entity/Bitrix24PartnerInterface.php
@@ -160,4 +160,17 @@ interface Bitrix24PartnerInterface
      * @throws InvalidArgumentException
      */
     public function setOpenLineId(?string $openLineId): void;
+
+    /**
+     * Get partner logo URL
+     */
+    public function getLogoUrl(): ?string;
+
+    /**
+     * Change partner logo URL
+     *
+     * @param non-empty-string|null $logoUrl
+     * @throws InvalidArgumentException
+     */
+    public function changeLogoUrl(?string $logoUrl): void;
 }

--- a/src/Application/Contracts/Bitrix24Partners/Events/Bitrix24PartnerLogoUrlChangedEvent.php
+++ b/src/Application/Contracts/Bitrix24Partners/Events/Bitrix24PartnerLogoUrlChangedEvent.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * This file is part of the bitrix24-php-sdk package.
+ *
+ * © Maksim Mesilov <mesilov.maxim@gmail.com>
+ *
+ * For the full copyright and license information, please view the MIT-LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Bitrix24\SDK\Application\Contracts\Bitrix24Partners\Events;
+
+use Carbon\CarbonImmutable;
+use Symfony\Component\Uid\Uuid;
+use Symfony\Contracts\EventDispatcher\Event;
+
+class Bitrix24PartnerLogoUrlChangedEvent extends Event
+{
+    public function __construct(
+        public readonly Uuid            $bitrix24PartnerId,
+        public readonly CarbonImmutable $timestamp,
+        public readonly ?string         $previousLogoUrl,
+        public readonly ?string         $currentLogoUrl)
+    {
+    }
+}

--- a/tests/Application/Contracts/Bitrix24Partners/Entity/Bitrix24PartnerInterfaceTest.php
+++ b/tests/Application/Contracts/Bitrix24Partners/Entity/Bitrix24PartnerInterfaceTest.php
@@ -45,7 +45,8 @@ abstract class Bitrix24PartnerInterfaceTest extends TestCase
         ?PhoneNumber          $phoneNumber,
         ?string               $email,
         ?string               $openLineId,
-        ?string               $externalId
+        ?string               $externalId,
+        ?string               $logoUrl = null
     ): Bitrix24PartnerInterface|AggregateRootEventsEmitterInterface;
 
     #[Test]
@@ -63,10 +64,11 @@ abstract class Bitrix24PartnerInterfaceTest extends TestCase
         ?string               $email,
         ?string               $openLineId,
         ?string               $externalId,
+        ?string               $logoUrl,
         string                $comment
     ): void
     {
-        $bitrix24Partner = $this->createBitrix24PartnerImplementation($uuid, $createdAt, $updatedAt, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId);
+        $bitrix24Partner = $this->createBitrix24PartnerImplementation($uuid, $createdAt, $updatedAt, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId, $logoUrl);
         $this->assertEquals($uuid, $bitrix24Partner->getId());
     }
 
@@ -85,10 +87,11 @@ abstract class Bitrix24PartnerInterfaceTest extends TestCase
         ?string               $email,
         ?string               $openLineId,
         ?string               $externalId,
+        ?string               $logoUrl,
         string                $comment
     ): void
     {
-        $bitrix24Partner = $this->createBitrix24PartnerImplementation($uuid, $createdAt, $updatedAt, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId);
+        $bitrix24Partner = $this->createBitrix24PartnerImplementation($uuid, $createdAt, $updatedAt, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId, $logoUrl);
         $this->assertEquals($createdAt, $bitrix24Partner->getCreatedAt());
     }
 
@@ -110,10 +113,11 @@ abstract class Bitrix24PartnerInterfaceTest extends TestCase
         ?string               $email,
         ?string               $openLineId,
         ?string               $externalId,
+        ?string               $logoUrl,
         string                $comment
     ): void
     {
-        $bitrix24Partner = $this->createBitrix24PartnerImplementation($uuid, $createdAt, $updatedAt, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId);
+        $bitrix24Partner = $this->createBitrix24PartnerImplementation($uuid, $createdAt, $updatedAt, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId, $logoUrl);
         $bitrix24Partner->setTitle('new title');
         $this->assertNotEquals($updatedAt, $bitrix24Partner->getUpdatedAt());
     }
@@ -133,10 +137,11 @@ abstract class Bitrix24PartnerInterfaceTest extends TestCase
         ?string               $email,
         ?string               $openLineId,
         ?string               $externalId,
+        ?string               $logoUrl,
         string                $comment
     ): void
     {
-        $bitrix24Partner = $this->createBitrix24PartnerImplementation($uuid, $createdAt, $updatedAt, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId);
+        $bitrix24Partner = $this->createBitrix24PartnerImplementation($uuid, $createdAt, $updatedAt, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId, $logoUrl);
 
         $newExternalId = Uuid::v7()->toRfc4122();
         $bitrix24Partner->setExternalId($newExternalId);
@@ -161,10 +166,11 @@ abstract class Bitrix24PartnerInterfaceTest extends TestCase
         ?string               $email,
         ?string               $openLineId,
         ?string               $externalId,
+        ?string               $logoUrl,
         string                $comment
     ): void
     {
-        $bitrix24Partner = $this->createBitrix24PartnerImplementation($uuid, $createdAt, $updatedAt, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId);
+        $bitrix24Partner = $this->createBitrix24PartnerImplementation($uuid, $createdAt, $updatedAt, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId, $logoUrl);
         $bitrix24Partner->setExternalId(null);
         $this->assertNull($bitrix24Partner->getExternalId());
     }
@@ -184,10 +190,11 @@ abstract class Bitrix24PartnerInterfaceTest extends TestCase
         ?string               $email,
         ?string               $openLineId,
         ?string               $externalId,
+        ?string               $logoUrl,
         string                $comment
     ): void
     {
-        $bitrix24Partner = $this->createBitrix24PartnerImplementation($uuid, $createdAt, $updatedAt, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId);
+        $bitrix24Partner = $this->createBitrix24PartnerImplementation($uuid, $createdAt, $updatedAt, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId, $logoUrl);
         $this->expectException(InvalidArgumentException::class);
         /** @phpstan-ignore-next-line */
         $bitrix24Partner->setExternalId('');
@@ -208,10 +215,11 @@ abstract class Bitrix24PartnerInterfaceTest extends TestCase
         ?string               $email,
         ?string               $openLineId,
         ?string               $externalId,
+        ?string               $logoUrl,
         string                $comment
     ): void
     {
-        $bitrix24Partner = $this->createBitrix24PartnerImplementation($uuid, $createdAt, $updatedAt, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId);
+        $bitrix24Partner = $this->createBitrix24PartnerImplementation($uuid, $createdAt, $updatedAt, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId, $logoUrl);
         $this->assertEquals($bitrix24PartnerStatus, $bitrix24Partner->getStatus());
     }
 
@@ -233,10 +241,11 @@ abstract class Bitrix24PartnerInterfaceTest extends TestCase
         ?string               $email,
         ?string               $openLineId,
         ?string               $externalId,
+        ?string               $logoUrl,
         string                $comment
     ): void
     {
-        $bitrix24Partner = $this->createBitrix24PartnerImplementation($uuid, $createdAt, $updatedAt, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId);
+        $bitrix24Partner = $this->createBitrix24PartnerImplementation($uuid, $createdAt, $updatedAt, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId, $logoUrl);
 
         $blockComment = 'block partner';
         $bitrix24Partner->markAsBlocked($blockComment);
@@ -266,10 +275,11 @@ abstract class Bitrix24PartnerInterfaceTest extends TestCase
         ?string               $email,
         ?string               $openLineId,
         ?string               $externalId,
+        ?string               $logoUrl,
         string                $comment
     ): void
     {
-        $bitrix24Partner = $this->createBitrix24PartnerImplementation($uuid, $createdAt, $updatedAt, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId);
+        $bitrix24Partner = $this->createBitrix24PartnerImplementation($uuid, $createdAt, $updatedAt, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId, $logoUrl);
 
         $blockComment = 'block partner';
         $bitrix24Partner->markAsBlocked($blockComment);
@@ -295,10 +305,11 @@ abstract class Bitrix24PartnerInterfaceTest extends TestCase
         ?string               $email,
         ?string               $openLineId,
         ?string               $externalId,
+        ?string               $logoUrl,
         string                $comment
     ): void
     {
-        $bitrix24Partner = $this->createBitrix24PartnerImplementation($uuid, $createdAt, $updatedAt, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId);
+        $bitrix24Partner = $this->createBitrix24PartnerImplementation($uuid, $createdAt, $updatedAt, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId, $logoUrl);
 
         $comment = 'delete partner';
         $bitrix24Partner->markAsDeleted($comment);
@@ -324,10 +335,11 @@ abstract class Bitrix24PartnerInterfaceTest extends TestCase
         ?string               $email,
         ?string               $openLineId,
         ?string               $externalId,
+        ?string               $logoUrl,
         string                $comment
     ): void
     {
-        $bitrix24Partner = $this->createBitrix24PartnerImplementation($uuid, $createdAt, $updatedAt, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId);
+        $bitrix24Partner = $this->createBitrix24PartnerImplementation($uuid, $createdAt, $updatedAt, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId, $logoUrl);
         $this->assertEquals($title, $bitrix24Partner->getTitle());
     }
 
@@ -346,10 +358,11 @@ abstract class Bitrix24PartnerInterfaceTest extends TestCase
         ?string               $email,
         ?string               $openLineId,
         ?string               $externalId,
+        ?string               $logoUrl,
         string                $comment
     ): void
     {
-        $bitrix24Partner = $this->createBitrix24PartnerImplementation($uuid, $createdAt, $updatedAt, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId);
+        $bitrix24Partner = $this->createBitrix24PartnerImplementation($uuid, $createdAt, $updatedAt, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId, $logoUrl);
         $newTitle = 'new title';
         $bitrix24Partner->setTitle($newTitle);
         $this->assertEquals($newTitle, $bitrix24Partner->getTitle());
@@ -375,10 +388,11 @@ abstract class Bitrix24PartnerInterfaceTest extends TestCase
         ?string               $email,
         ?string               $openLineId,
         ?string               $externalId,
+        ?string               $logoUrl,
         string                $comment
     ): void
     {
-        $bitrix24Partner = $this->createBitrix24PartnerImplementation($uuid, $createdAt, $updatedAt, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId);
+        $bitrix24Partner = $this->createBitrix24PartnerImplementation($uuid, $createdAt, $updatedAt, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId, $logoUrl);
         $this->assertEquals($site, $bitrix24Partner->getSite());
     }
 
@@ -400,10 +414,11 @@ abstract class Bitrix24PartnerInterfaceTest extends TestCase
         ?string               $email,
         ?string               $openLineId,
         ?string               $externalId,
+        ?string               $logoUrl,
         string                $comment
     ): void
     {
-        $bitrix24Partner = $this->createBitrix24PartnerImplementation($uuid, $createdAt, $updatedAt, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId);
+        $bitrix24Partner = $this->createBitrix24PartnerImplementation($uuid, $createdAt, $updatedAt, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId, $logoUrl);
         $newSite = 'https://new-partner-site.com';
         $bitrix24Partner->setSite($newSite);
         $this->assertEquals($newSite, $bitrix24Partner->getSite());
@@ -431,10 +446,11 @@ abstract class Bitrix24PartnerInterfaceTest extends TestCase
         ?string               $email,
         ?string               $openLineId,
         ?string               $externalId,
+        ?string               $logoUrl,
         string                $comment
     ): void
     {
-        $bitrix24Partner = $this->createBitrix24PartnerImplementation($uuid, $createdAt, $updatedAt, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId);
+        $bitrix24Partner = $this->createBitrix24PartnerImplementation($uuid, $createdAt, $updatedAt, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId, $logoUrl);
         $this->assertEquals($phoneNumber, $bitrix24Partner->getPhone());
     }
 
@@ -453,10 +469,11 @@ abstract class Bitrix24PartnerInterfaceTest extends TestCase
         ?string               $email,
         ?string               $openLineId,
         ?string               $externalId,
+        ?string               $logoUrl,
         string                $comment
     ): void
     {
-        $bitrix24Partner = $this->createBitrix24PartnerImplementation($uuid, $createdAt, $updatedAt, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId);
+        $bitrix24Partner = $this->createBitrix24PartnerImplementation($uuid, $createdAt, $updatedAt, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId, $logoUrl);
         $newPhone = DemoDataGenerator::getMobilePhone();
         $bitrix24Partner->setPhone($newPhone);
         $this->assertEquals($newPhone, $bitrix24Partner->getPhone());
@@ -480,10 +497,11 @@ abstract class Bitrix24PartnerInterfaceTest extends TestCase
         ?string               $email,
         ?string               $openLineId,
         ?string               $externalId,
+        ?string               $logoUrl,
         string                $comment
     ): void
     {
-        $bitrix24Partner = $this->createBitrix24PartnerImplementation($uuid, $createdAt, $updatedAt, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId);
+        $bitrix24Partner = $this->createBitrix24PartnerImplementation($uuid, $createdAt, $updatedAt, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId, $logoUrl);
         $this->assertEquals($email, $bitrix24Partner->getEmail());
     }
 
@@ -502,10 +520,11 @@ abstract class Bitrix24PartnerInterfaceTest extends TestCase
         ?string               $email,
         ?string               $openLineId,
         ?string               $externalId,
+        ?string               $logoUrl,
         string                $comment
     ): void
     {
-        $bitrix24Partner = $this->createBitrix24PartnerImplementation($uuid, $createdAt, $updatedAt, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId);
+        $bitrix24Partner = $this->createBitrix24PartnerImplementation($uuid, $createdAt, $updatedAt, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId, $logoUrl);
 
         $newEmail = DemoDataGenerator::getEmail();
         $bitrix24Partner->setEmail($newEmail);
@@ -534,10 +553,11 @@ abstract class Bitrix24PartnerInterfaceTest extends TestCase
         ?string               $email,
         ?string               $openLineId,
         ?string               $externalId,
+        ?string               $logoUrl,
         string                $comment
     ): void
     {
-        $bitrix24Partner = $this->createBitrix24PartnerImplementation($uuid, $createdAt, $updatedAt, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId);
+        $bitrix24Partner = $this->createBitrix24PartnerImplementation($uuid, $createdAt, $updatedAt, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId, $logoUrl);
 
         $newEmail = '@partner.com';
         $this->expectException(InvalidArgumentException::class);
@@ -559,10 +579,11 @@ abstract class Bitrix24PartnerInterfaceTest extends TestCase
         ?string               $email,
         ?string               $openLineId,
         ?string               $externalId,
+        ?string               $logoUrl,
         string                $comment
     ): void
     {
-        $bitrix24Partner = $this->createBitrix24PartnerImplementation($uuid, $createdAt, $updatedAt, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId);
+        $bitrix24Partner = $this->createBitrix24PartnerImplementation($uuid, $createdAt, $updatedAt, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId, $logoUrl);
         $this->assertEquals($bitrix24PartnerNumber, $bitrix24Partner->getBitrix24PartnerNumber());
     }
 
@@ -581,10 +602,11 @@ abstract class Bitrix24PartnerInterfaceTest extends TestCase
         ?string               $email,
         ?string               $openLineId,
         ?string               $externalId,
+        ?string               $logoUrl,
         string                $comment
     ): void
     {
-        $bitrix24Partner = $this->createBitrix24PartnerImplementation($uuid, $createdAt, $updatedAt, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId);
+        $bitrix24Partner = $this->createBitrix24PartnerImplementation($uuid, $createdAt, $updatedAt, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId, $logoUrl);
         $this->assertEquals($openLineId, $bitrix24Partner->getOpenLineId());
     }
 
@@ -603,10 +625,11 @@ abstract class Bitrix24PartnerInterfaceTest extends TestCase
         ?string               $email,
         ?string               $openLineId,
         ?string               $externalId,
+        ?string               $logoUrl,
         string                $comment
     ): void
     {
-        $bitrix24Partner = $this->createBitrix24PartnerImplementation($uuid, $createdAt, $updatedAt, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId);
+        $bitrix24Partner = $this->createBitrix24PartnerImplementation($uuid, $createdAt, $updatedAt, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId, $logoUrl);
         $newOpenLineId = Uuid::v7()->toRfc4122();
         $bitrix24Partner->setOpenLineId($newOpenLineId);
         $this->assertEquals($newOpenLineId, $bitrix24Partner->getOpenLineId());
@@ -617,6 +640,65 @@ abstract class Bitrix24PartnerInterfaceTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         /** @phpstan-ignore-next-line */
         $bitrix24Partner->setOpenLineId('');
+    }
+
+    #[Test]
+    #[DataProvider('bitrix24PartnerDataProvider')]
+    #[TestDox('test getLogoUrl method')]
+    final public function testGetLogoUrl(
+        Uuid                  $uuid,
+        CarbonImmutable       $createdAt,
+        CarbonImmutable       $updatedAt,
+        Bitrix24PartnerStatus $bitrix24PartnerStatus,
+        string                $title,
+        int                   $bitrix24PartnerNumber,
+        ?string               $site,
+        ?PhoneNumber          $phoneNumber,
+        ?string               $email,
+        ?string               $openLineId,
+        ?string               $externalId,
+        ?string               $logoUrl,
+        string                $comment
+    ): void
+    {
+        $bitrix24Partner = $this->createBitrix24PartnerImplementation($uuid, $createdAt, $updatedAt, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId, $logoUrl);
+        $this->assertEquals($logoUrl, $bitrix24Partner->getLogoUrl());
+    }
+
+    /**
+     * @throws InvalidArgumentException
+     */
+    #[Test]
+    #[DataProvider('bitrix24PartnerDataProvider')]
+    #[TestDox('test changeLogoUrl method')]
+    final public function testChangeLogoUrl(
+        Uuid                  $uuid,
+        CarbonImmutable       $createdAt,
+        CarbonImmutable       $updatedAt,
+        Bitrix24PartnerStatus $bitrix24PartnerStatus,
+        string                $title,
+        int                   $bitrix24PartnerNumber,
+        ?string               $site,
+        ?PhoneNumber          $phoneNumber,
+        ?string               $email,
+        ?string               $openLineId,
+        ?string               $externalId,
+        ?string               $logoUrl,
+        string                $comment
+    ): void
+    {
+        $bitrix24Partner = $this->createBitrix24PartnerImplementation($uuid, $createdAt, $updatedAt, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId, $logoUrl);
+
+        $newLogoUrl = 'https://new-partner-logo.example.com/logo.png';
+        $bitrix24Partner->changeLogoUrl($newLogoUrl);
+        $this->assertEquals($newLogoUrl, $bitrix24Partner->getLogoUrl());
+
+        $bitrix24Partner->changeLogoUrl(null);
+        $this->assertNull($bitrix24Partner->getLogoUrl());
+
+        $this->expectException(InvalidArgumentException::class);
+        /** @phpstan-ignore-next-line */
+        $bitrix24Partner->changeLogoUrl('');
     }
 
     /**
@@ -637,6 +719,7 @@ abstract class Bitrix24PartnerInterfaceTest extends TestCase
             DemoDataGenerator::getEmail(), // email, optional
             'open-line-id', // open line id, optional
             Uuid::v7()->toRfc4122(), // externalId, optional
+            'https://partner-logo.example.com/logo.png', // logoUrl, optional
             'comment', // comment, optional
         ];
     }

--- a/tests/Unit/Application/Contracts/Bitrix24Partners/Entity/Bitrix24PartnerInterfaceReferenceImplementationTest.php
+++ b/tests/Unit/Application/Contracts/Bitrix24Partners/Entity/Bitrix24PartnerInterfaceReferenceImplementationTest.php
@@ -36,7 +36,8 @@ class Bitrix24PartnerInterfaceReferenceImplementationTest extends Bitrix24Partne
         ?PhoneNumber          $phoneNumber,
         ?string               $email,
         ?string               $openLineId,
-        ?string               $externalId): Bitrix24PartnerInterface
+        ?string               $externalId,
+        ?string               $logoUrl = null): Bitrix24PartnerInterface
     {
         return new Bitrix24PartnerReferenceEntityImplementation(
             $uuid,
@@ -49,7 +50,8 @@ class Bitrix24PartnerInterfaceReferenceImplementationTest extends Bitrix24Partne
             $phoneNumber,
             $email,
             $openLineId,
-            $externalId
+            $externalId,
+            $logoUrl
         );
     }
 }

--- a/tests/Unit/Application/Contracts/Bitrix24Partners/Entity/Bitrix24PartnerReferenceEntityImplementation.php
+++ b/tests/Unit/Application/Contracts/Bitrix24Partners/Entity/Bitrix24PartnerReferenceEntityImplementation.php
@@ -53,7 +53,8 @@ final class Bitrix24PartnerReferenceEntityImplementation implements Bitrix24Part
         private ?PhoneNumber             $phoneNumber,
         private ?string                  $email,
         private ?string                  $openLineId,
-        private ?string                  $externalId
+        private ?string                  $externalId,
+        private ?string                  $logoUrl = null
     )
     {
         if ($bitrix24PartnerNumber <= 0) {
@@ -262,5 +263,22 @@ final class Bitrix24PartnerReferenceEntityImplementation implements Bitrix24Part
     public function getComment(): ?string
     {
         return $this->comment;
+    }
+
+    #[\Override]
+    public function getLogoUrl(): ?string
+    {
+        return $this->logoUrl;
+    }
+
+    #[\Override]
+    public function changeLogoUrl(?string $logoUrl): void
+    {
+        if ($logoUrl !== null && trim($logoUrl) === '') {
+            throw new InvalidArgumentException('logoUrl cannot be an empty string');
+        }
+
+        $this->logoUrl = $logoUrl;
+        $this->updatedAt = new CarbonImmutable();
     }
 }


### PR DESCRIPTION
| Q             | A                                                                                                                         |
|---------------|---------------------------------------------------------------------------------------------------------------------------|
| Bug fix?      | no                                                                                                                        |
| New feature?  | yes                                                                                                                       |
| Deprecations? | no                                                                                                                        |
| Issues        | Fix #452                                                                                                                  |
| License       | **MIT**                                                                                                                   |

## Description

This PR extends the `Bitrix24PartnerInterface` contract with logo URL support, addressing issue #452.

### Changes

**New Files:**
- `src/Application/Contracts/Bitrix24Partners/Events/Bitrix24PartnerLogoUrlChangedEvent.php` – Domain event for logo URL changes

**Modified Files:**
- `src/Application/Contracts/Bitrix24Partners/Entity/Bitrix24PartnerInterface.php` – Added two new methods:
  - `getLogoUrl(): ?string` – Returns the partner's logo URL or null if not set
  - `changeLogoUrl(?string $logoUrl): void` – Updates the logo URL; throws `InvalidArgumentException` on empty string; accepts null to clear

- `tests/Unit/Application/Contracts/Bitrix24Partners/Entity/Bitrix24PartnerReferenceEntityImplementation.php` – Implemented the new methods with validation (rejects empty strings, accepts null)

- `tests/Application/Contracts/Bitrix24Partners/Entity/Bitrix24PartnerInterfaceTest.php` – Updated all test methods to include the new `$logoUrl` parameter and added two new test methods:
  - `testGetLogoUrl()` – Verifies getter returns the correct value
  - `testChangeLogoUrl()` – Verifies setter works correctly and rejects empty strings

- `tests/Unit/Application/Contracts/Bitrix24Partners/Entity/Bitrix24PartnerInterfaceReferenceImplementationTest.php` – Updated factory method to pass `$logoUrl` parameter

- `CHANGELOG.md` – Documented the new feature

### Design

The logo URL follows the same pattern as existing optional string properties (`site`, `email`, `openLineId`):
- Nullable string type
- Getter returns the current value or null
- Setter validates against empty strings but accepts null
- Updates the `updatedAt` timestamp on change

### Testing

All existing tests pass with the new parameter added. New test methods verify:
- Logo URL getter returns the correct value
- Logo URL setter updates the value correctly
- Logo URL setter accepts null to clear the value
- Logo URL setter throws `InvalidArgumentException` on empty string

Closes #452

https://claude.ai/code/session_01VR7pw7WCs9gSuvVdLEnnAZ