### PR TITLE
Fix User\Batch::get() yielding DealItemResult instead of UserItemResult

### DIFF
--- a/.tasks/447/plan.md
+++ b/.tasks/447/plan.md
@@ -1,0 +1,40 @@
+# Plan: Fix User Batch::get() returns DealItemResult instead of UserItemResult (issue #447)
+
+## Context
+
+`src/Services/User/Service/Batch.php` was copy-pasted from the CRM Deal scope and the
+`DealItemResult` import was never replaced. As a result, every item yielded by `Batch::get()`
+is an instance of `DealItemResult` instead of `UserItemResult`.
+
+`UserItemResult` already exists at `src/Services/User/Result/UserItemResult.php` with all
+`@property-read` annotations — no new class is needed.
+
+---
+
+## Files to Modify
+
+### 1. `src/Services/User/Service/Batch.php`
+
+- Replace `use Bitrix24\SDK\Services\CRM\Deal\Result\DealItemResult;`
+  with `use Bitrix24\SDK\Services\User\Result\UserItemResult;`
+- Replace `yield $key => new DealItemResult($value);`
+  with `yield $key => new UserItemResult($value);`
+
+---
+
+## Deptrac compliance
+
+`Services` layer uses another class within the same `Services` layer — both are under
+`src/Services/User/`, so no cross-layer violation is introduced.
+
+---
+
+## Verification
+
+```bash
+make lint-cs-fixer
+make lint-rector
+make lint-phpstan
+make lint-deptrac
+make test-unit
+```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@
 - Updated `b24phpsdk-maintainer` skill: generalized the placements workflow to cover `PlacementLocationCodes`, typed `Placements` facades, `PlacementLangMap`/`PlacementLangItem`, `LangCodes` placement, service-builder registration, docs links, and the full unit/integration test matrix
 - Updated `b24phpsdk-maintainer` skill: moved the detailed placements workflow into a dedicated adjacent guide to keep `SKILL.md` compact while preserving the full placement implementation playbook
 
+### Fixed
+
+- Fixed `User\Service\Batch::get()` yielding `DealItemResult` instead of `UserItemResult` ([#447](https://github.com/bitrix24/b24phpsdk/issues/447))
+
 ## 3.1.0
 
 ### Added

--- a/src/Services/User/Service/Batch.php
+++ b/src/Services/User/Service/Batch.php
@@ -18,7 +18,7 @@ use Bitrix24\SDK\Attributes\ApiBatchServiceMetadata;
 use Bitrix24\SDK\Core\Contracts\BatchOperationsInterface;
 use Bitrix24\SDK\Core\Credentials\Scope;
 use Bitrix24\SDK\Core\Result\AddedItemBatchResult;
-use Bitrix24\SDK\Services\CRM\Deal\Result\DealItemResult;
+use Bitrix24\SDK\Services\User\Result\UserItemResult;
 use Generator;
 use Psr\Log\LoggerInterface;
 
@@ -80,7 +80,7 @@ class Batch
                 ]
             ) as $key => $value
         ) {
-            yield $key => new DealItemResult($value);
+            yield $key => new UserItemResult($value);
         }
     }
 }


### PR DESCRIPTION
| Q             | A                                                                                                             |
|---------------|---------------------------------------------------------------------------------------------------------------|
| Bug fix?      | yes                                                                                                           |
| New feature?  | no                                                                                                            |
| Deprecations? | no                                                                                                            |
| Issues        | Fix #447                                                                                                      |
| License       | **MIT**                                                                                                       |

`User\Service\Batch::get()` was returning `DealItemResult` instances instead of the correct
`UserItemResult`. The file was originally copy-pasted from the CRM Deal scope and the wrong
import was never corrected.

**Change**: replace the `use Bitrix24\SDK\Services\CRM\Deal\Result\DealItemResult` import
with `use Bitrix24\SDK\Services\User\Result\UserItemResult` and update the `yield` statement
accordingly. `UserItemResult` already existed with full `@property-read` annotations — no new
class needed.

Closes #447

---
_Generated by [Claude Code](https://claude.ai/code/session_017Miv8Ms52w9tsxDKZxyJQS)_