### PR TITLE
Fix Bitrix24PartnerInterfaceTest contract to allow internal timestamp initialization

### DIFF
--- a/.tasks/457/plan.md
+++ b/.tasks/457/plan.md
@@ -1,0 +1,115 @@
+# Plan: Fix Bitrix24Partner unit test contract (issue #457)
+
+## Context
+
+The downstream library `bitrix24-php-lib` defines a concrete
+`Bitrix24Partner` entity whose constructor initialises `createdAt` and
+`updatedAt` internally with `new CarbonImmutable()` (those fields are not
+part of the constructor signature). When the consumer wires its
+`Bitrix24Partner` into the abstract test contract
+`Bitrix24PartnerInterfaceTest` shipped by this SDK, the contract still
+forwards `$createdAt` / `$updatedAt` from the data provider through the
+factory. The implementation ignores those parameters and produces fresh
+timestamps instead, which leads to microsecond-level mismatches and a
+failing `testGetCreatedAt`:
+
+```
+✘ test getCreatedAt method with partner-status-active-all-fields
+  Failed asserting that two DateTime objects are equal.
+  -2026-04-27T09:32:46.279637+0000
+  +2026-04-27T09:32:46.465616+0000
+```
+
+The interface itself (`Bitrix24PartnerInterface`) exposes
+`getCreatedAt()` / `getUpdatedAt()` but defines no setters and does not
+require these timestamps as construction inputs — they are an
+implementation detail, just like in `Bitrix24AccountInterface`. The
+matching `Bitrix24AccountInterfaceTest` already follows this convention:
+the abstract factory does not take `createdAt` / `updatedAt`, and the
+`testGetUpdatedAt` test asserts that after a state change
+`getUpdatedAt()` is no longer equal to `getCreatedAt()`.
+
+The fix: align `Bitrix24PartnerInterfaceTest` with the
+`Bitrix24AccountInterfaceTest` convention so the contract works for any
+implementation that initialises timestamps internally.
+
+---
+
+## Files to Modify
+
+### 1. `tests/Application/Contracts/Bitrix24Partners/Entity/Bitrix24PartnerInterfaceTest.php`
+
+Changes:
+
+1. Drop `CarbonImmutable $createdAt` and `CarbonImmutable $updatedAt`
+   from the abstract `createBitrix24PartnerImplementation()` signature.
+2. Drop the same two parameters from every `final public function
+   testXxx(...)` signature in the file and from every call to
+   `$this->createBitrix24PartnerImplementation(...)`.
+3. Drop the two `CarbonImmutable::now()` entries from the
+   `bitrix24PartnerDataProvider()` yielded array.
+4. Remove `testGetCreatedAt(...)` entirely — without an externally
+   supplied value, the contract has nothing meaningful to assert; the
+   `getCreatedAt()` return type is already enforced by PHP.
+5. Rewrite `testGetUpdatedAt(...)` to follow the
+   `Bitrix24AccountInterfaceTest` pattern: after `changeTitle('new title')`
+   assert that `getUpdatedAt()` is **not equal** to `getCreatedAt()`
+   (the implementation must bump `updatedAt` on every mutation).
+6. Drop `use Carbon\CarbonImmutable;` if it becomes unused after the
+   above edits.
+
+### 2. `tests/Unit/Application/Contracts/Bitrix24Partners/Entity/Bitrix24PartnerInterfaceReferenceImplementationTest.php`
+
+Update the override of `createBitrix24PartnerImplementation()` so its
+signature matches the new abstract one and stop forwarding
+`$createdAt` / `$updatedAt` to the reference entity constructor.
+
+### 3. `tests/Unit/Application/Contracts/Bitrix24Partners/Entity/Bitrix24PartnerReferenceEntityImplementation.php`
+
+Mirror the real downstream `Bitrix24Partner`: remove `$createdAt` and
+`$updatedAt` from the constructor signature and initialise both
+properties with `new CarbonImmutable()` inside the constructor body.
+The two `getCreatedAt()` / `getUpdatedAt()` getters are unchanged.
+
+### 4. `CHANGELOG.md`
+
+Add under `## 3.2.0 Unreleased` → `### Fixed`:
+
+```
+- Fix `Bitrix24PartnerInterfaceTest` contract — drop `createdAt` / `updatedAt`
+  from the abstract factory so implementations can initialise timestamps
+  internally without microsecond-level mismatches
+  ([#457](https://github.com/bitrix24/b24phpsdk/issues/457))
+```
+
+---
+
+## Files to Create
+
+None. This is a test-contract bug fix; no new public API or service is added.
+
+---
+
+## Deptrac compliance
+
+All edits live in `tests/` and only touch types already imported in the
+modified files (`CarbonImmutable`, the existing reference entity). No
+new cross-layer imports are introduced.
+
+---
+
+## Verification
+
+```bash
+make lint-cs-fixer
+make lint-rector
+make lint-phpstan
+make lint-deptrac
+make test-unit
+```
+
+The relevant unit suite covers
+`Bitrix24PartnerInterfaceReferenceImplementationTest`, which exercises
+every contract test method through the reference entity. No integration
+test target applies (this is an Application-layer contract, not a REST
+service).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 ### Fixed
 
 - Fixed `User\Service\Batch::get()` yielding `DealItemResult` instead of `UserItemResult` ([#447](https://github.com/bitrix24/b24phpsdk/issues/447))
+- Fixed abstract `Bitrix24PartnerInterfaceTest` and `Bitrix24PartnerRepositoryInterfaceTest` contracts: dropped `createdAt` / `updatedAt` from the factory method signature and data provider so implementations that initialise both timestamps internally (e.g. `new CarbonImmutable()` in the constructor) no longer fail with microsecond mismatches ([#457](https://github.com/bitrix24/b24phpsdk/issues/457))
 
 ## 3.1.0
 

--- a/tests/Application/Contracts/Bitrix24Partners/Entity/Bitrix24PartnerInterfaceTest.php
+++ b/tests/Application/Contracts/Bitrix24Partners/Entity/Bitrix24PartnerInterfaceTest.php
@@ -15,11 +15,9 @@ namespace Bitrix24\SDK\Tests\Application\Contracts\Bitrix24Partners\Entity;
 
 use Bitrix24\SDK\Application\Contracts\Bitrix24Partners\Entity\Bitrix24PartnerInterface;
 use Bitrix24\SDK\Application\Contracts\Bitrix24Partners\Entity\Bitrix24PartnerStatus;
-use Bitrix24\SDK\Application\Contracts\Bitrix24Partners\Events\Bitrix24PartnerExternalIdChangedEvent;
 use Bitrix24\SDK\Application\Contracts\Events\AggregateRootEventsEmitterInterface;
 use Bitrix24\SDK\Core\Exceptions\InvalidArgumentException;
 use Bitrix24\SDK\Tests\Builders\DemoDataGenerator;
-use Carbon\CarbonImmutable;
 use Generator;
 use libphonenumber\NumberParseException;
 use libphonenumber\PhoneNumber;
@@ -29,15 +27,12 @@ use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\Attributes\TestDox;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Uid\Uuid;
-use Throwable;
 
 #[CoversClass(Bitrix24PartnerInterface::class)]
 abstract class Bitrix24PartnerInterfaceTest extends TestCase
 {
     abstract protected function createBitrix24PartnerImplementation(
         Uuid                  $uuid,
-        CarbonImmutable       $createdAt,
-        CarbonImmutable       $updatedAt,
         Bitrix24PartnerStatus $bitrix24PartnerStatus,
         string                $title,
         int                   $bitrix24PartnerNumber,
@@ -54,8 +49,6 @@ abstract class Bitrix24PartnerInterfaceTest extends TestCase
     #[TestDox('test getId method')]
     final public function testGetId(
         Uuid                  $uuid,
-        CarbonImmutable       $createdAt,
-        CarbonImmutable       $updatedAt,
         Bitrix24PartnerStatus $bitrix24PartnerStatus,
         string                $title,
         int                   $bitrix24PartnerNumber,
@@ -66,33 +59,9 @@ abstract class Bitrix24PartnerInterfaceTest extends TestCase
         ?string               $externalId,
         ?string               $logoUrl,
         string                $comment
-    ): void
-    {
-        $bitrix24Partner = $this->createBitrix24PartnerImplementation($uuid, $createdAt, $updatedAt, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId, $logoUrl);
+    ): void {
+        $bitrix24Partner = $this->createBitrix24PartnerImplementation($uuid, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId, $logoUrl);
         $this->assertEquals($uuid, $bitrix24Partner->getId());
-    }
-
-    #[Test]
-    #[DataProvider('bitrix24PartnerDataProvider')]
-    #[TestDox('test getCreatedAt method')]
-    final public function testGetCreatedAt(
-        Uuid                  $uuid,
-        CarbonImmutable       $createdAt,
-        CarbonImmutable       $updatedAt,
-        Bitrix24PartnerStatus $bitrix24PartnerStatus,
-        string                $title,
-        int                   $bitrix24PartnerNumber,
-        ?string               $site,
-        ?PhoneNumber          $phoneNumber,
-        ?string               $email,
-        ?string               $openLineId,
-        ?string               $externalId,
-        ?string               $logoUrl,
-        string                $comment
-    ): void
-    {
-        $bitrix24Partner = $this->createBitrix24PartnerImplementation($uuid, $createdAt, $updatedAt, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId, $logoUrl);
-        $this->assertEquals($createdAt, $bitrix24Partner->getCreatedAt());
     }
 
     /**
@@ -103,8 +72,6 @@ abstract class Bitrix24PartnerInterfaceTest extends TestCase
     #[TestDox('test getUpdatedAt method')]
     final public function testGetUpdatedAt(
         Uuid                  $uuid,
-        CarbonImmutable       $createdAt,
-        CarbonImmutable       $updatedAt,
         Bitrix24PartnerStatus $bitrix24PartnerStatus,
         string                $title,
         int                   $bitrix24PartnerNumber,
@@ -115,11 +82,10 @@ abstract class Bitrix24PartnerInterfaceTest extends TestCase
         ?string               $externalId,
         ?string               $logoUrl,
         string                $comment
-    ): void
-    {
-        $bitrix24Partner = $this->createBitrix24PartnerImplementation($uuid, $createdAt, $updatedAt, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId, $logoUrl);
+    ): void {
+        $bitrix24Partner = $this->createBitrix24PartnerImplementation($uuid, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId, $logoUrl);
         $bitrix24Partner->changeTitle('new title');
-        $this->assertNotEquals($updatedAt, $bitrix24Partner->getUpdatedAt());
+        $this->assertFalse($bitrix24Partner->getUpdatedAt()->equalTo($bitrix24Partner->getCreatedAt()));
     }
 
     #[Test]
@@ -127,8 +93,6 @@ abstract class Bitrix24PartnerInterfaceTest extends TestCase
     #[TestDox('test changeExternalId method with empty string')]
     final public function testChangeExternalId(
         Uuid                  $uuid,
-        CarbonImmutable       $createdAt,
-        CarbonImmutable       $updatedAt,
         Bitrix24PartnerStatus $bitrix24PartnerStatus,
         string                $title,
         int                   $bitrix24PartnerNumber,
@@ -139,9 +103,8 @@ abstract class Bitrix24PartnerInterfaceTest extends TestCase
         ?string               $externalId,
         ?string               $logoUrl,
         string                $comment
-    ): void
-    {
-        $bitrix24Partner = $this->createBitrix24PartnerImplementation($uuid, $createdAt, $updatedAt, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId, $logoUrl);
+    ): void {
+        $bitrix24Partner = $this->createBitrix24PartnerImplementation($uuid, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId, $logoUrl);
 
         $newExternalId = Uuid::v7()->toRfc4122();
         $bitrix24Partner->changeExternalId($newExternalId);
@@ -156,8 +119,6 @@ abstract class Bitrix24PartnerInterfaceTest extends TestCase
     #[TestDox('test changeExternalId method with null')]
     final public function testChangeExternalIdWithNull(
         Uuid                  $uuid,
-        CarbonImmutable       $createdAt,
-        CarbonImmutable       $updatedAt,
         Bitrix24PartnerStatus $bitrix24PartnerStatus,
         string                $title,
         int                   $bitrix24PartnerNumber,
@@ -168,9 +129,8 @@ abstract class Bitrix24PartnerInterfaceTest extends TestCase
         ?string               $externalId,
         ?string               $logoUrl,
         string                $comment
-    ): void
-    {
-        $bitrix24Partner = $this->createBitrix24PartnerImplementation($uuid, $createdAt, $updatedAt, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId, $logoUrl);
+    ): void {
+        $bitrix24Partner = $this->createBitrix24PartnerImplementation($uuid, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId, $logoUrl);
         $bitrix24Partner->changeExternalId(null);
         $this->assertNull($bitrix24Partner->getExternalId());
     }
@@ -180,8 +140,6 @@ abstract class Bitrix24PartnerInterfaceTest extends TestCase
     #[TestDox('test changeExternalId method')]
     final public function testChangeExternalIdWithEmptyString(
         Uuid                  $uuid,
-        CarbonImmutable       $createdAt,
-        CarbonImmutable       $updatedAt,
         Bitrix24PartnerStatus $bitrix24PartnerStatus,
         string                $title,
         int                   $bitrix24PartnerNumber,
@@ -192,9 +150,8 @@ abstract class Bitrix24PartnerInterfaceTest extends TestCase
         ?string               $externalId,
         ?string               $logoUrl,
         string                $comment
-    ): void
-    {
-        $bitrix24Partner = $this->createBitrix24PartnerImplementation($uuid, $createdAt, $updatedAt, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId, $logoUrl);
+    ): void {
+        $bitrix24Partner = $this->createBitrix24PartnerImplementation($uuid, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId, $logoUrl);
         $this->expectException(InvalidArgumentException::class);
         /** @phpstan-ignore-next-line */
         $bitrix24Partner->changeExternalId('');
@@ -205,8 +162,6 @@ abstract class Bitrix24PartnerInterfaceTest extends TestCase
     #[TestDox('test getStatus method')]
     final public function testGetStatus(
         Uuid                  $uuid,
-        CarbonImmutable       $createdAt,
-        CarbonImmutable       $updatedAt,
         Bitrix24PartnerStatus $bitrix24PartnerStatus,
         string                $title,
         int                   $bitrix24PartnerNumber,
@@ -217,9 +172,8 @@ abstract class Bitrix24PartnerInterfaceTest extends TestCase
         ?string               $externalId,
         ?string               $logoUrl,
         string                $comment
-    ): void
-    {
-        $bitrix24Partner = $this->createBitrix24PartnerImplementation($uuid, $createdAt, $updatedAt, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId, $logoUrl);
+    ): void {
+        $bitrix24Partner = $this->createBitrix24PartnerImplementation($uuid, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId, $logoUrl);
         $this->assertEquals($bitrix24PartnerStatus, $bitrix24Partner->getStatus());
     }
 
@@ -231,8 +185,6 @@ abstract class Bitrix24PartnerInterfaceTest extends TestCase
     #[TestDox('test markAsActive method')]
     final public function testMarkAsActive(
         Uuid                  $uuid,
-        CarbonImmutable       $createdAt,
-        CarbonImmutable       $updatedAt,
         Bitrix24PartnerStatus $bitrix24PartnerStatus,
         string                $title,
         int                   $bitrix24PartnerNumber,
@@ -243,9 +195,8 @@ abstract class Bitrix24PartnerInterfaceTest extends TestCase
         ?string               $externalId,
         ?string               $logoUrl,
         string                $comment
-    ): void
-    {
-        $bitrix24Partner = $this->createBitrix24PartnerImplementation($uuid, $createdAt, $updatedAt, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId, $logoUrl);
+    ): void {
+        $bitrix24Partner = $this->createBitrix24PartnerImplementation($uuid, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId, $logoUrl);
 
         $blockComment = 'block partner';
         $bitrix24Partner->markAsBlocked($blockComment);
@@ -265,8 +216,6 @@ abstract class Bitrix24PartnerInterfaceTest extends TestCase
     #[TestDox('test markAsBlocked method')]
     final public function testMarkAsBlocked(
         Uuid                  $uuid,
-        CarbonImmutable       $createdAt,
-        CarbonImmutable       $updatedAt,
         Bitrix24PartnerStatus $bitrix24PartnerStatus,
         string                $title,
         int                   $bitrix24PartnerNumber,
@@ -277,9 +226,8 @@ abstract class Bitrix24PartnerInterfaceTest extends TestCase
         ?string               $externalId,
         ?string               $logoUrl,
         string                $comment
-    ): void
-    {
-        $bitrix24Partner = $this->createBitrix24PartnerImplementation($uuid, $createdAt, $updatedAt, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId, $logoUrl);
+    ): void {
+        $bitrix24Partner = $this->createBitrix24PartnerImplementation($uuid, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId, $logoUrl);
 
         $blockComment = 'block partner';
         $bitrix24Partner->markAsBlocked($blockComment);
@@ -295,8 +243,6 @@ abstract class Bitrix24PartnerInterfaceTest extends TestCase
     #[TestDox('test markAsBlocked method')]
     final public function testMarkAsDeleted(
         Uuid                  $uuid,
-        CarbonImmutable       $createdAt,
-        CarbonImmutable       $updatedAt,
         Bitrix24PartnerStatus $bitrix24PartnerStatus,
         string                $title,
         int                   $bitrix24PartnerNumber,
@@ -307,9 +253,8 @@ abstract class Bitrix24PartnerInterfaceTest extends TestCase
         ?string               $externalId,
         ?string               $logoUrl,
         string                $comment
-    ): void
-    {
-        $bitrix24Partner = $this->createBitrix24PartnerImplementation($uuid, $createdAt, $updatedAt, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId, $logoUrl);
+    ): void {
+        $bitrix24Partner = $this->createBitrix24PartnerImplementation($uuid, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId, $logoUrl);
 
         $comment = 'delete partner';
         $bitrix24Partner->markAsDeleted($comment);
@@ -325,8 +270,6 @@ abstract class Bitrix24PartnerInterfaceTest extends TestCase
     #[TestDox('test getTitle method')]
     final public function testGetTitle(
         Uuid                  $uuid,
-        CarbonImmutable       $createdAt,
-        CarbonImmutable       $updatedAt,
         Bitrix24PartnerStatus $bitrix24PartnerStatus,
         string                $title,
         int                   $bitrix24PartnerNumber,
@@ -337,9 +280,8 @@ abstract class Bitrix24PartnerInterfaceTest extends TestCase
         ?string               $externalId,
         ?string               $logoUrl,
         string                $comment
-    ): void
-    {
-        $bitrix24Partner = $this->createBitrix24PartnerImplementation($uuid, $createdAt, $updatedAt, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId, $logoUrl);
+    ): void {
+        $bitrix24Partner = $this->createBitrix24PartnerImplementation($uuid, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId, $logoUrl);
         $this->assertEquals($title, $bitrix24Partner->getTitle());
     }
 
@@ -348,8 +290,6 @@ abstract class Bitrix24PartnerInterfaceTest extends TestCase
     #[TestDox('test changeTitle method')]
     final public function testChangeTitle(
         Uuid                  $uuid,
-        CarbonImmutable       $createdAt,
-        CarbonImmutable       $updatedAt,
         Bitrix24PartnerStatus $bitrix24PartnerStatus,
         string                $title,
         int                   $bitrix24PartnerNumber,
@@ -360,9 +300,8 @@ abstract class Bitrix24PartnerInterfaceTest extends TestCase
         ?string               $externalId,
         ?string               $logoUrl,
         string                $comment
-    ): void
-    {
-        $bitrix24Partner = $this->createBitrix24PartnerImplementation($uuid, $createdAt, $updatedAt, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId, $logoUrl);
+    ): void {
+        $bitrix24Partner = $this->createBitrix24PartnerImplementation($uuid, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId, $logoUrl);
         $newTitle = 'new title';
         $bitrix24Partner->changeTitle($newTitle);
         $this->assertEquals($newTitle, $bitrix24Partner->getTitle());
@@ -378,8 +317,6 @@ abstract class Bitrix24PartnerInterfaceTest extends TestCase
     #[TestDox('test getSite method')]
     final public function testGetSite(
         Uuid                  $uuid,
-        CarbonImmutable       $createdAt,
-        CarbonImmutable       $updatedAt,
         Bitrix24PartnerStatus $bitrix24PartnerStatus,
         string                $title,
         int                   $bitrix24PartnerNumber,
@@ -390,9 +327,8 @@ abstract class Bitrix24PartnerInterfaceTest extends TestCase
         ?string               $externalId,
         ?string               $logoUrl,
         string                $comment
-    ): void
-    {
-        $bitrix24Partner = $this->createBitrix24PartnerImplementation($uuid, $createdAt, $updatedAt, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId, $logoUrl);
+    ): void {
+        $bitrix24Partner = $this->createBitrix24PartnerImplementation($uuid, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId, $logoUrl);
         $this->assertEquals($site, $bitrix24Partner->getSite());
     }
 
@@ -404,8 +340,6 @@ abstract class Bitrix24PartnerInterfaceTest extends TestCase
     #[TestDox('test changeSite method')]
     final public function testChangeSite(
         Uuid                  $uuid,
-        CarbonImmutable       $createdAt,
-        CarbonImmutable       $updatedAt,
         Bitrix24PartnerStatus $bitrix24PartnerStatus,
         string                $title,
         int                   $bitrix24PartnerNumber,
@@ -416,9 +350,8 @@ abstract class Bitrix24PartnerInterfaceTest extends TestCase
         ?string               $externalId,
         ?string               $logoUrl,
         string                $comment
-    ): void
-    {
-        $bitrix24Partner = $this->createBitrix24PartnerImplementation($uuid, $createdAt, $updatedAt, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId, $logoUrl);
+    ): void {
+        $bitrix24Partner = $this->createBitrix24PartnerImplementation($uuid, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId, $logoUrl);
         $newSite = 'https://new-partner-site.com';
         $bitrix24Partner->changeSite($newSite);
         $this->assertEquals($newSite, $bitrix24Partner->getSite());
@@ -436,8 +369,6 @@ abstract class Bitrix24PartnerInterfaceTest extends TestCase
     #[TestDox('test getPhone method')]
     final public function testGetPhone(
         Uuid                  $uuid,
-        CarbonImmutable       $createdAt,
-        CarbonImmutable       $updatedAt,
         Bitrix24PartnerStatus $bitrix24PartnerStatus,
         string                $title,
         int                   $bitrix24PartnerNumber,
@@ -448,9 +379,8 @@ abstract class Bitrix24PartnerInterfaceTest extends TestCase
         ?string               $externalId,
         ?string               $logoUrl,
         string                $comment
-    ): void
-    {
-        $bitrix24Partner = $this->createBitrix24PartnerImplementation($uuid, $createdAt, $updatedAt, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId, $logoUrl);
+    ): void {
+        $bitrix24Partner = $this->createBitrix24PartnerImplementation($uuid, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId, $logoUrl);
         $this->assertEquals($phoneNumber, $bitrix24Partner->getPhone());
     }
 
@@ -459,8 +389,6 @@ abstract class Bitrix24PartnerInterfaceTest extends TestCase
     #[TestDox('test changePhone method')]
     final public function testChangePhone(
         Uuid                  $uuid,
-        CarbonImmutable       $createdAt,
-        CarbonImmutable       $updatedAt,
         Bitrix24PartnerStatus $bitrix24PartnerStatus,
         string                $title,
         int                   $bitrix24PartnerNumber,
@@ -471,9 +399,8 @@ abstract class Bitrix24PartnerInterfaceTest extends TestCase
         ?string               $externalId,
         ?string               $logoUrl,
         string                $comment
-    ): void
-    {
-        $bitrix24Partner = $this->createBitrix24PartnerImplementation($uuid, $createdAt, $updatedAt, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId, $logoUrl);
+    ): void {
+        $bitrix24Partner = $this->createBitrix24PartnerImplementation($uuid, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId, $logoUrl);
         $newPhone = DemoDataGenerator::getMobilePhone();
         $bitrix24Partner->changePhone($newPhone);
         $this->assertEquals($newPhone, $bitrix24Partner->getPhone());
@@ -487,8 +414,6 @@ abstract class Bitrix24PartnerInterfaceTest extends TestCase
     #[TestDox('test getEmail method')]
     final public function testGetEmail(
         Uuid                  $uuid,
-        CarbonImmutable       $createdAt,
-        CarbonImmutable       $updatedAt,
         Bitrix24PartnerStatus $bitrix24PartnerStatus,
         string                $title,
         int                   $bitrix24PartnerNumber,
@@ -499,9 +424,8 @@ abstract class Bitrix24PartnerInterfaceTest extends TestCase
         ?string               $externalId,
         ?string               $logoUrl,
         string                $comment
-    ): void
-    {
-        $bitrix24Partner = $this->createBitrix24PartnerImplementation($uuid, $createdAt, $updatedAt, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId, $logoUrl);
+    ): void {
+        $bitrix24Partner = $this->createBitrix24PartnerImplementation($uuid, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId, $logoUrl);
         $this->assertEquals($email, $bitrix24Partner->getEmail());
     }
 
@@ -510,8 +434,6 @@ abstract class Bitrix24PartnerInterfaceTest extends TestCase
     #[TestDox('test changeEmail method')]
     final public function testChangeEmail(
         Uuid                  $uuid,
-        CarbonImmutable       $createdAt,
-        CarbonImmutable       $updatedAt,
         Bitrix24PartnerStatus $bitrix24PartnerStatus,
         string                $title,
         int                   $bitrix24PartnerNumber,
@@ -522,9 +444,8 @@ abstract class Bitrix24PartnerInterfaceTest extends TestCase
         ?string               $externalId,
         ?string               $logoUrl,
         string                $comment
-    ): void
-    {
-        $bitrix24Partner = $this->createBitrix24PartnerImplementation($uuid, $createdAt, $updatedAt, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId, $logoUrl);
+    ): void {
+        $bitrix24Partner = $this->createBitrix24PartnerImplementation($uuid, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId, $logoUrl);
 
         $newEmail = DemoDataGenerator::getEmail();
         $bitrix24Partner->changeEmail($newEmail);
@@ -543,8 +464,6 @@ abstract class Bitrix24PartnerInterfaceTest extends TestCase
     #[TestDox('test changeEmail method with invalid email')]
     final public function testChangeEmailWithInvalidEmail(
         Uuid                  $uuid,
-        CarbonImmutable       $createdAt,
-        CarbonImmutable       $updatedAt,
         Bitrix24PartnerStatus $bitrix24PartnerStatus,
         string                $title,
         int                   $bitrix24PartnerNumber,
@@ -555,9 +474,8 @@ abstract class Bitrix24PartnerInterfaceTest extends TestCase
         ?string               $externalId,
         ?string               $logoUrl,
         string                $comment
-    ): void
-    {
-        $bitrix24Partner = $this->createBitrix24PartnerImplementation($uuid, $createdAt, $updatedAt, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId, $logoUrl);
+    ): void {
+        $bitrix24Partner = $this->createBitrix24PartnerImplementation($uuid, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId, $logoUrl);
 
         $newEmail = '@partner.com';
         $this->expectException(InvalidArgumentException::class);
@@ -569,8 +487,6 @@ abstract class Bitrix24PartnerInterfaceTest extends TestCase
     #[TestDox('test getBitrix24PartnerNumber')]
     final public function testGetBitrix24PartnerNumber(
         Uuid                  $uuid,
-        CarbonImmutable       $createdAt,
-        CarbonImmutable       $updatedAt,
         Bitrix24PartnerStatus $bitrix24PartnerStatus,
         string                $title,
         int                   $bitrix24PartnerNumber,
@@ -581,9 +497,8 @@ abstract class Bitrix24PartnerInterfaceTest extends TestCase
         ?string               $externalId,
         ?string               $logoUrl,
         string                $comment
-    ): void
-    {
-        $bitrix24Partner = $this->createBitrix24PartnerImplementation($uuid, $createdAt, $updatedAt, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId, $logoUrl);
+    ): void {
+        $bitrix24Partner = $this->createBitrix24PartnerImplementation($uuid, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId, $logoUrl);
         $this->assertEquals($bitrix24PartnerNumber, $bitrix24Partner->getBitrix24PartnerNumber());
     }
 
@@ -592,8 +507,6 @@ abstract class Bitrix24PartnerInterfaceTest extends TestCase
     #[TestDox('test getOpenLineId')]
     final public function testGetOpenLineId(
         Uuid                  $uuid,
-        CarbonImmutable       $createdAt,
-        CarbonImmutable       $updatedAt,
         Bitrix24PartnerStatus $bitrix24PartnerStatus,
         string                $title,
         int                   $bitrix24PartnerNumber,
@@ -604,9 +517,8 @@ abstract class Bitrix24PartnerInterfaceTest extends TestCase
         ?string               $externalId,
         ?string               $logoUrl,
         string                $comment
-    ): void
-    {
-        $bitrix24Partner = $this->createBitrix24PartnerImplementation($uuid, $createdAt, $updatedAt, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId, $logoUrl);
+    ): void {
+        $bitrix24Partner = $this->createBitrix24PartnerImplementation($uuid, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId, $logoUrl);
         $this->assertEquals($openLineId, $bitrix24Partner->getOpenLineId());
     }
 
@@ -615,8 +527,6 @@ abstract class Bitrix24PartnerInterfaceTest extends TestCase
     #[TestDox('test changeOpenLineId')]
     final public function testChangeOpenLineId(
         Uuid                  $uuid,
-        CarbonImmutable       $createdAt,
-        CarbonImmutable       $updatedAt,
         Bitrix24PartnerStatus $bitrix24PartnerStatus,
         string                $title,
         int                   $bitrix24PartnerNumber,
@@ -627,9 +537,8 @@ abstract class Bitrix24PartnerInterfaceTest extends TestCase
         ?string               $externalId,
         ?string               $logoUrl,
         string                $comment
-    ): void
-    {
-        $bitrix24Partner = $this->createBitrix24PartnerImplementation($uuid, $createdAt, $updatedAt, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId, $logoUrl);
+    ): void {
+        $bitrix24Partner = $this->createBitrix24PartnerImplementation($uuid, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId, $logoUrl);
         $newOpenLineId = Uuid::v7()->toRfc4122();
         $bitrix24Partner->changeOpenLineId($newOpenLineId);
         $this->assertEquals($newOpenLineId, $bitrix24Partner->getOpenLineId());
@@ -647,8 +556,6 @@ abstract class Bitrix24PartnerInterfaceTest extends TestCase
     #[TestDox('test getLogoUrl method')]
     final public function testGetLogoUrl(
         Uuid                  $uuid,
-        CarbonImmutable       $createdAt,
-        CarbonImmutable       $updatedAt,
         Bitrix24PartnerStatus $bitrix24PartnerStatus,
         string                $title,
         int                   $bitrix24PartnerNumber,
@@ -659,9 +566,8 @@ abstract class Bitrix24PartnerInterfaceTest extends TestCase
         ?string               $externalId,
         ?string               $logoUrl,
         string                $comment
-    ): void
-    {
-        $bitrix24Partner = $this->createBitrix24PartnerImplementation($uuid, $createdAt, $updatedAt, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId, $logoUrl);
+    ): void {
+        $bitrix24Partner = $this->createBitrix24PartnerImplementation($uuid, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId, $logoUrl);
         $this->assertEquals($logoUrl, $bitrix24Partner->getLogoUrl());
     }
 
@@ -673,8 +579,6 @@ abstract class Bitrix24PartnerInterfaceTest extends TestCase
     #[TestDox('test changeLogoUrl method')]
     final public function testChangeLogoUrl(
         Uuid                  $uuid,
-        CarbonImmutable       $createdAt,
-        CarbonImmutable       $updatedAt,
         Bitrix24PartnerStatus $bitrix24PartnerStatus,
         string                $title,
         int                   $bitrix24PartnerNumber,
@@ -685,9 +589,8 @@ abstract class Bitrix24PartnerInterfaceTest extends TestCase
         ?string               $externalId,
         ?string               $logoUrl,
         string                $comment
-    ): void
-    {
-        $bitrix24Partner = $this->createBitrix24PartnerImplementation($uuid, $createdAt, $updatedAt, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId, $logoUrl);
+    ): void {
+        $bitrix24Partner = $this->createBitrix24PartnerImplementation($uuid, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId, $logoUrl);
 
         $newLogoUrl = 'https://new-partner-logo.example.com/logo.png';
         $bitrix24Partner->changeLogoUrl($newLogoUrl);
@@ -709,8 +612,6 @@ abstract class Bitrix24PartnerInterfaceTest extends TestCase
     {
         yield 'partner-status-active-all-fields' => [
             Uuid::v7(), //id
-            CarbonImmutable::now(), // createdAt
-            CarbonImmutable::now(), // updatedAt
             Bitrix24PartnerStatus::active,
             'Bitrix24 Partner LLC', // title
             12345, // bitrix24 partner number, optional

--- a/tests/Application/Contracts/Bitrix24Partners/Repository/Bitrix24PartnerRepositoryInterfaceTest.php
+++ b/tests/Application/Contracts/Bitrix24Partners/Repository/Bitrix24PartnerRepositoryInterfaceTest.php
@@ -20,7 +20,6 @@ use Bitrix24\SDK\Application\Contracts\Bitrix24Partners\Repository\Bitrix24Partn
 use Bitrix24\SDK\Core\Exceptions\InvalidArgumentException;
 use Bitrix24\SDK\Tests\Application\Contracts\TestRepositoryFlusherInterface;
 use Bitrix24\SDK\Tests\Builders\DemoDataGenerator;
-use Carbon\CarbonImmutable;
 use Generator;
 use libphonenumber\NumberParseException;
 use libphonenumber\PhoneNumber;
@@ -36,8 +35,6 @@ abstract class Bitrix24PartnerRepositoryInterfaceTest extends TestCase
 {
     abstract protected function createBitrix24PartnerImplementation(
         Uuid                  $uuid,
-        CarbonImmutable       $createdAt,
-        CarbonImmutable       $updatedAt,
         Bitrix24PartnerStatus $bitrix24PartnerStatus,
         string                $title,
         ?int                  $bitrix24PartnerNumber,
@@ -45,7 +42,8 @@ abstract class Bitrix24PartnerRepositoryInterfaceTest extends TestCase
         ?PhoneNumber          $phoneNumber,
         ?string               $email,
         ?string               $openLineId,
-        ?string               $externalId): Bitrix24PartnerInterface;
+        ?string               $externalId
+    ): Bitrix24PartnerInterface;
 
     abstract protected function createBitrix24PartnerRepositoryImplementation(): Bitrix24PartnerRepositoryInterface;
 
@@ -60,8 +58,6 @@ abstract class Bitrix24PartnerRepositoryInterfaceTest extends TestCase
     #[TestDox('test save method')]
     final public function testSave(
         Uuid                  $uuid,
-        CarbonImmutable       $createdAt,
-        CarbonImmutable       $updatedAt,
         Bitrix24PartnerStatus $bitrix24PartnerStatus,
         string                $title,
         ?int                  $bitrix24PartnerNumber,
@@ -71,9 +67,8 @@ abstract class Bitrix24PartnerRepositoryInterfaceTest extends TestCase
         ?string               $openLineId,
         ?string               $externalId,
         string                $comment
-    ): void
-    {
-        $b24Partner = $this->createBitrix24PartnerImplementation($uuid, $createdAt, $updatedAt, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId);
+    ): void {
+        $b24Partner = $this->createBitrix24PartnerImplementation($uuid, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId);
         $b24PartnerRepository = $this->createBitrix24PartnerRepositoryImplementation();
         $flusher = $this->createRepositoryFlusherImplementation();
 
@@ -93,8 +88,6 @@ abstract class Bitrix24PartnerRepositoryInterfaceTest extends TestCase
     #[TestDox('test save with two bitrix24partner number')]
     final public function testSaveWithTwoBitrix24PartnerNumber(
         Uuid                  $uuid,
-        CarbonImmutable       $createdAt,
-        CarbonImmutable       $updatedAt,
         Bitrix24PartnerStatus $bitrix24PartnerStatus,
         string                $title,
         ?int                  $bitrix24PartnerNumber,
@@ -104,9 +97,8 @@ abstract class Bitrix24PartnerRepositoryInterfaceTest extends TestCase
         ?string               $openLineId,
         ?string               $externalId,
         string                $comment
-    ): void
-    {
-        $b24Partner = $this->createBitrix24PartnerImplementation($uuid, $createdAt, $updatedAt, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId);
+    ): void {
+        $b24Partner = $this->createBitrix24PartnerImplementation($uuid, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId);
         $b24PartnerRepository = $this->createBitrix24PartnerRepositoryImplementation();
         $flusher = $this->createRepositoryFlusherImplementation();
 
@@ -116,7 +108,7 @@ abstract class Bitrix24PartnerRepositoryInterfaceTest extends TestCase
         $res = $b24PartnerRepository->getById($b24Partner->getId());
         $this->assertEquals($b24Partner, $res);
 
-        $secondB24Partner = $this->createBitrix24PartnerImplementation(Uuid::v7(), $createdAt, $updatedAt, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId);
+        $secondB24Partner = $this->createBitrix24PartnerImplementation(Uuid::v7(), $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId);
         $this->expectException(InvalidArgumentException::class);
         $b24PartnerRepository->save($secondB24Partner);
     }
@@ -130,8 +122,6 @@ abstract class Bitrix24PartnerRepositoryInterfaceTest extends TestCase
     #[TestDox('test delete method')]
     final public function testDelete(
         Uuid                  $uuid,
-        CarbonImmutable       $createdAt,
-        CarbonImmutable       $updatedAt,
         Bitrix24PartnerStatus $bitrix24PartnerStatus,
         string                $title,
         ?int                  $bitrix24PartnerNumber,
@@ -141,9 +131,8 @@ abstract class Bitrix24PartnerRepositoryInterfaceTest extends TestCase
         ?string               $openLineId,
         ?string               $externalId,
         string                $comment
-    ): void
-    {
-        $b24Partner = $this->createBitrix24PartnerImplementation($uuid, $createdAt, $updatedAt, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId);
+    ): void {
+        $b24Partner = $this->createBitrix24PartnerImplementation($uuid, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId);
         $b24PartnerRepository = $this->createBitrix24PartnerRepositoryImplementation();
         $flusher = $this->createRepositoryFlusherImplementation();
 
@@ -166,8 +155,6 @@ abstract class Bitrix24PartnerRepositoryInterfaceTest extends TestCase
     #[TestDox('test save method')]
     final public function testGetById(
         Uuid                  $uuid,
-        CarbonImmutable       $createdAt,
-        CarbonImmutable       $updatedAt,
         Bitrix24PartnerStatus $bitrix24PartnerStatus,
         string                $title,
         ?int                  $bitrix24PartnerNumber,
@@ -177,9 +164,8 @@ abstract class Bitrix24PartnerRepositoryInterfaceTest extends TestCase
         ?string               $openLineId,
         ?string               $externalId,
         string                $comment
-    ): void
-    {
-        $b24Partner = $this->createBitrix24PartnerImplementation($uuid, $createdAt, $updatedAt, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId);
+    ): void {
+        $b24Partner = $this->createBitrix24PartnerImplementation($uuid, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId);
         $b24PartnerRepository = $this->createBitrix24PartnerRepositoryImplementation();
         $flusher = $this->createRepositoryFlusherImplementation();
 
@@ -201,8 +187,6 @@ abstract class Bitrix24PartnerRepositoryInterfaceTest extends TestCase
     #[TestDox('test findByBitrix24PartnerNumber method')]
     final public function testFindByBitrix24PartnerNumber(
         Uuid                  $uuid,
-        CarbonImmutable       $createdAt,
-        CarbonImmutable       $updatedAt,
         Bitrix24PartnerStatus $bitrix24PartnerStatus,
         string                $title,
         ?int                  $bitrix24PartnerNumber,
@@ -212,9 +196,8 @@ abstract class Bitrix24PartnerRepositoryInterfaceTest extends TestCase
         ?string               $openLineId,
         ?string               $externalId,
         string                $comment
-    ): void
-    {
-        $b24Partner = $this->createBitrix24PartnerImplementation($uuid, $createdAt, $updatedAt, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId);
+    ): void {
+        $b24Partner = $this->createBitrix24PartnerImplementation($uuid, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId);
         $b24PartnerRepository = $this->createBitrix24PartnerRepositoryImplementation();
         $flusher = $this->createRepositoryFlusherImplementation();
 
@@ -232,8 +215,6 @@ abstract class Bitrix24PartnerRepositoryInterfaceTest extends TestCase
     #[TestDox('test findByTitle method')]
     final public function testFindByTitle(
         Uuid                  $uuid,
-        CarbonImmutable       $createdAt,
-        CarbonImmutable       $updatedAt,
         Bitrix24PartnerStatus $bitrix24PartnerStatus,
         string                $title,
         ?int                  $bitrix24PartnerNumber,
@@ -243,9 +224,8 @@ abstract class Bitrix24PartnerRepositoryInterfaceTest extends TestCase
         ?string               $openLineId,
         ?string               $externalId,
         string                $comment
-    ): void
-    {
-        $b24Partner = $this->createBitrix24PartnerImplementation($uuid, $createdAt, $updatedAt, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId);
+    ): void {
+        $b24Partner = $this->createBitrix24PartnerImplementation($uuid, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId);
         $b24PartnerRepository = $this->createBitrix24PartnerRepositoryImplementation();
         $flusher = $this->createRepositoryFlusherImplementation();
 
@@ -263,8 +243,6 @@ abstract class Bitrix24PartnerRepositoryInterfaceTest extends TestCase
     #[TestDox('test findByExternalId method')]
     final public function testFindByExternalId(
         Uuid                  $uuid,
-        CarbonImmutable       $createdAt,
-        CarbonImmutable       $updatedAt,
         Bitrix24PartnerStatus $bitrix24PartnerStatus,
         string                $title,
         ?int                  $bitrix24PartnerNumber,
@@ -274,9 +252,8 @@ abstract class Bitrix24PartnerRepositoryInterfaceTest extends TestCase
         ?string               $openLineId,
         ?string               $externalId,
         string                $comment
-    ): void
-    {
-        $b24Partner = $this->createBitrix24PartnerImplementation($uuid, $createdAt, $updatedAt, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId);
+    ): void {
+        $b24Partner = $this->createBitrix24PartnerImplementation($uuid, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId);
         $b24PartnerRepository = $this->createBitrix24PartnerRepositoryImplementation();
         $flusher = $this->createRepositoryFlusherImplementation();
 
@@ -297,8 +274,6 @@ abstract class Bitrix24PartnerRepositoryInterfaceTest extends TestCase
     {
         yield 'partner-status-active-all-fields' => [
             Uuid::v7(), //id
-            CarbonImmutable::now(), // createdAt
-            CarbonImmutable::now(), // updatedAt
             Bitrix24PartnerStatus::active,
             'Bitrix24 Partner LLC', // title
             12345, // bitrix24 partner number, optional

--- a/tests/Unit/Application/Contracts/Bitrix24Partners/Entity/Bitrix24PartnerInterfaceReferenceImplementationTest.php
+++ b/tests/Unit/Application/Contracts/Bitrix24Partners/Entity/Bitrix24PartnerInterfaceReferenceImplementationTest.php
@@ -16,7 +16,6 @@ namespace Bitrix24\SDK\Tests\Unit\Application\Contracts\Bitrix24Partners\Entity;
 use Bitrix24\SDK\Application\Contracts\Bitrix24Partners\Entity\Bitrix24PartnerInterface;
 use Bitrix24\SDK\Application\Contracts\Bitrix24Partners\Entity\Bitrix24PartnerStatus;
 use Bitrix24\SDK\Tests\Application\Contracts\Bitrix24Partners\Entity\Bitrix24PartnerInterfaceTest;
-use Carbon\CarbonImmutable;
 use libphonenumber\PhoneNumber;
 use PHPUnit\Framework\Attributes\CoversClass;
 use Symfony\Component\Uid\Uuid;
@@ -27,8 +26,6 @@ class Bitrix24PartnerInterfaceReferenceImplementationTest extends Bitrix24Partne
     #[\Override]
     protected function createBitrix24PartnerImplementation(
         Uuid                  $uuid,
-        CarbonImmutable       $createdAt,
-        CarbonImmutable       $updatedAt,
         Bitrix24PartnerStatus $bitrix24PartnerStatus,
         string                $title,
         int                   $bitrix24PartnerId,
@@ -37,12 +34,10 @@ class Bitrix24PartnerInterfaceReferenceImplementationTest extends Bitrix24Partne
         ?string               $email,
         ?string               $openLineId,
         ?string               $externalId,
-        ?string               $logoUrl = null): Bitrix24PartnerInterface
-    {
+        ?string               $logoUrl = null
+    ): Bitrix24PartnerInterface {
         return new Bitrix24PartnerReferenceEntityImplementation(
             $uuid,
-            $createdAt,
-            $updatedAt,
             $bitrix24PartnerStatus,
             $title,
             $bitrix24PartnerId,

--- a/tests/Unit/Application/Contracts/Bitrix24Partners/Entity/Bitrix24PartnerReferenceEntityImplementation.php
+++ b/tests/Unit/Application/Contracts/Bitrix24Partners/Entity/Bitrix24PartnerReferenceEntityImplementation.php
@@ -42,24 +42,28 @@ final class Bitrix24PartnerReferenceEntityImplementation implements Bitrix24Part
 
     private array $events = [];
 
+    private readonly CarbonImmutable $createdAt;
+
+    private CarbonImmutable $updatedAt;
+
     public function __construct(
-        private readonly Uuid            $id,
-        private readonly CarbonImmutable $createdAt,
-        private CarbonImmutable          $updatedAt,
-        private Bitrix24PartnerStatus    $bitrix24PartnerStatus,
-        private string                   $title,
-        private readonly int             $bitrix24PartnerNumber,
-        private ?string                  $site,
-        private ?PhoneNumber             $phoneNumber,
-        private ?string                  $email,
-        private ?string                  $openLineId,
-        private ?string                  $externalId,
-        private ?string                  $logoUrl = null
-    )
-    {
+        private readonly Uuid         $id,
+        private Bitrix24PartnerStatus $bitrix24PartnerStatus,
+        private string                $title,
+        private readonly int          $bitrix24PartnerNumber,
+        private ?string               $site,
+        private ?PhoneNumber          $phoneNumber,
+        private ?string               $email,
+        private ?string               $openLineId,
+        private ?string               $externalId,
+        private ?string               $logoUrl = null
+    ) {
         if ($bitrix24PartnerNumber <= 0) {
             throw new InvalidArgumentException(sprintf('bitrix24 partner number must be positive int, now «%s»', $bitrix24PartnerNumber));
         }
+
+        $this->createdAt = new CarbonImmutable();
+        $this->updatedAt = new CarbonImmutable();
     }
 
     #[\Override]
@@ -218,8 +222,11 @@ final class Bitrix24PartnerReferenceEntityImplementation implements Bitrix24Part
     {
         if (Bitrix24PartnerStatus::blocked !== $this->bitrix24PartnerStatus) {
             throw new InvalidArgumentException(
-                sprintf('you can activate bitrix24 partner only in status blocked, now bitrix24 partner in status %s',
-                    $this->bitrix24PartnerStatus->name));
+                sprintf(
+                    'you can activate bitrix24 partner only in status blocked, now bitrix24 partner in status %s',
+                    $this->bitrix24PartnerStatus->name
+                )
+            );
         }
 
         $this->bitrix24PartnerStatus = Bitrix24PartnerStatus::active;
@@ -235,9 +242,11 @@ final class Bitrix24PartnerReferenceEntityImplementation implements Bitrix24Part
     {
         if (Bitrix24PartnerStatus::deleted === $this->bitrix24PartnerStatus || Bitrix24PartnerStatus::blocked === $this->bitrix24PartnerStatus) {
             throw new InvalidArgumentException(
-                sprintf('you cannot block bitrix24 partner in status «%s»',
+                sprintf(
+                    'you cannot block bitrix24 partner in status «%s»',
                     $this->bitrix24PartnerStatus->name
-                ));
+                )
+            );
         }
 
         $this->bitrix24PartnerStatus = Bitrix24PartnerStatus::blocked;
@@ -250,8 +259,11 @@ final class Bitrix24PartnerReferenceEntityImplementation implements Bitrix24Part
     {
         if (Bitrix24PartnerStatus::deleted === $this->bitrix24PartnerStatus) {
             throw new InvalidArgumentException(
-                sprintf('you cannot mark bitrix24 partner as deleted in status %s',
-                    $this->bitrix24PartnerStatus->name));
+                sprintf(
+                    'you cannot mark bitrix24 partner as deleted in status %s',
+                    $this->bitrix24PartnerStatus->name
+                )
+            );
         }
 
         $this->bitrix24PartnerStatus = Bitrix24PartnerStatus::deleted;

--- a/tests/Unit/Application/Contracts/Bitrix24Partners/Repository/InMemoryBitrix24PartnerRepositoryImplementation.php
+++ b/tests/Unit/Application/Contracts/Bitrix24Partners/Repository/InMemoryBitrix24PartnerRepositoryImplementation.php
@@ -30,8 +30,7 @@ class InMemoryBitrix24PartnerRepositoryImplementation implements Bitrix24Partner
 
     public function __construct(
         private readonly LoggerInterface $logger
-    )
-    {
+    ) {
     }
 
     #[\Override]
@@ -141,7 +140,8 @@ class InMemoryBitrix24PartnerRepositoryImplementation implements Bitrix24Partner
 
         $bitrix24Partner = $this->getById($uuid);
         if (Bitrix24PartnerStatus::deleted !== $bitrix24Partner->getStatus()) {
-            throw new InvalidArgumentException(sprintf('you cannot delete bitrix24 partner item «%s», they must be in status deleted, current status «%s»',
+            throw new InvalidArgumentException(sprintf(
+                'you cannot delete bitrix24 partner item «%s», they must be in status deleted, current status «%s»',
                 $bitrix24Partner->getId()->toRfc4122(),
                 $bitrix24Partner->getStatus()->name
             ));

--- a/tests/Unit/Application/Contracts/Bitrix24Partners/Repository/InMemoryBitrix24PartnerRepositoryImplementationTest.php
+++ b/tests/Unit/Application/Contracts/Bitrix24Partners/Repository/InMemoryBitrix24PartnerRepositoryImplementationTest.php
@@ -45,8 +45,6 @@ class InMemoryBitrix24PartnerRepositoryImplementationTest extends Bitrix24Partne
     #[\Override]
     protected function createBitrix24PartnerImplementation(
         Uuid                  $uuid,
-        CarbonImmutable       $createdAt,
-        CarbonImmutable       $updatedAt,
         Bitrix24PartnerStatus $bitrix24PartnerStatus,
         string                $title,
         ?int                  $bitrix24PartnerId,
@@ -54,12 +52,10 @@ class InMemoryBitrix24PartnerRepositoryImplementationTest extends Bitrix24Partne
         ?PhoneNumber          $phoneNumber,
         ?string               $email,
         ?string               $openLineId,
-        ?string               $externalId): Bitrix24PartnerInterface
-    {
+        ?string               $externalId
+    ): Bitrix24PartnerInterface {
         return new Bitrix24PartnerReferenceEntityImplementation(
             $uuid,
-            $createdAt,
-            $updatedAt,
             $bitrix24PartnerStatus,
             $title,
             $bitrix24PartnerId,
@@ -67,7 +63,8 @@ class InMemoryBitrix24PartnerRepositoryImplementationTest extends Bitrix24Partne
             $phoneNumber,
             $email,
             $openLineId,
-            $externalId);
+            $externalId
+        );
     }
 
     #[\Override]


### PR DESCRIPTION
| Q             | A                                                                                                                         |
|---------------|---------------------------------------------------------------------------------------------------------------------------|
| Bug fix?      | yes                                                                                                                       |
| New feature?  | no                                                                                                                        |
| Deprecations? | no                                                                                                                        |
| Issues        | Fix #457                                                                                                                  |
| License       | **MIT**                                                                                                                   |

## Description

The `Bitrix24PartnerInterfaceTest` abstract test contract was requiring `createdAt` and `updatedAt` as constructor parameters in its factory method. This caused test failures in downstream implementations (like `bitrix24-php-lib`) that initialize these timestamps internally with `new CarbonImmutable()`, resulting in microsecond-level mismatches.

This fix aligns `Bitrix24PartnerInterfaceTest` with the existing `Bitrix24AccountInterfaceTest` pattern:

1. **Removed timestamp parameters** from the abstract `createBitrix24PartnerImplementation()` factory method signature
2. **Removed timestamp parameters** from all test method signatures and their calls to the factory
3. **Removed `testGetCreatedAt()`** — without an externally supplied value, the contract has nothing meaningful to assert
4. **Rewrote `testGetUpdatedAt()`** to verify that after a state change (e.g., `changeTitle()`), the `updatedAt` timestamp differs from `createdAt`, ensuring implementations properly track mutations
5. **Updated reference implementation** (`Bitrix24PartnerReferenceEntityImplementation`) to initialize both timestamps internally in the constructor
6. **Updated all test implementations** to match the new factory signature

The interface itself (`Bitrix24PartnerInterface`) already exposes `getCreatedAt()` and `getUpdatedAt()` without setters, confirming these are implementation details that should be managed internally.

## Test Plan

Existing unit tests cover this change:
- `Bitrix24PartnerInterfaceReferenceImplementationTest` exercises all contract test methods through the reference entity
- `InMemoryBitrix24PartnerRepositoryImplementationTest` validates repository operations with the updated factory

All tests pass with the new contract expectations.

https://claude.ai/code/session_01Bp3cAxzeR6q2UHensQivVs