### PR TITLE
Remove dead `delete()` method from Bitrix24PartnerRepositoryInterface

### DIFF
--- a/.tasks/471/plan.md
+++ b/.tasks/471/plan.md
@@ -1,0 +1,62 @@
+# Plan: Remove `delete(Uuid $uuid)` from `Bitrix24PartnerRepositoryInterface` (issue #471)
+
+## Context
+
+`Bitrix24PartnerRepositoryInterface` exposes a `delete(Uuid $uuid): void` method that is
+never invoked by any use case. The actual deletion flow is:
+
+1. `$partner->markAsDeleted(?string $comment)` — entity transitions to `deleted` status
+2. `$repository->save($partner)` — persists the state change
+3. `$flusher->flush($partner)` — flushes and dispatches domain events
+
+The `delete()` method in `InMemoryBitrix24PartnerRepositoryImplementation` physically
+removes the entity from in-memory storage only after verifying it is already in `deleted`
+status — replicating a business invariant that the entity itself already enforces.
+
+This is a pure refactoring with no behaviour change to any production use case.
+API version: v3 (branch base: `v3-dev`).
+
+---
+
+## Files to Modify
+
+### 1. `src/Application/Contracts/Bitrix24Partners/Repository/Bitrix24PartnerRepositoryInterface.php`
+
+Remove the `delete(Uuid $uuid): void` method declaration (lines 32-37).
+Check that the `InvalidArgumentException` import is still needed by remaining methods — it is
+(used by `save()`, `findByTitle()`, `findByExternalId()`), so leave it in place.
+
+### 2. `tests/Unit/Application/Contracts/Bitrix24Partners/Repository/InMemoryBitrix24PartnerRepositoryImplementation.php`
+
+Remove the `delete()` method implementation (lines 136-151).
+The `Uuid` import remains required by `getById()`.
+
+### 3. `tests/Application/Contracts/Bitrix24Partners/Repository/Bitrix24PartnerRepositoryInterfaceTest.php`
+
+Remove the `testDelete()` test method (lines 120-147).
+
+### 4. `CHANGELOG.md`
+
+Add under `## X.Y.Z Unreleased` → `### Changed` (or `### Removed`):
+
+```
+- Removed dead `delete(Uuid $uuid)` method from `Bitrix24PartnerRepositoryInterface` and its test/stub implementations ([#471](https://github.com/bitrix24/b24phpsdk/issues/471))
+```
+
+---
+
+## Deptrac compliance
+
+No new classes or imports are introduced. Only method removals. No new layer violations possible.
+
+---
+
+## Verification
+
+```bash
+make lint-cs-fixer
+make lint-rector
+make lint-phpstan
+make lint-deptrac
+make test-unit
+```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 
 ### Changed
 
+- Removed dead `delete(Uuid $uuid)` method from `Bitrix24PartnerRepositoryInterface`, its in-memory stub implementation, and the `testDelete` contract test — the soft-delete flow (`markAsDeleted()` + `save()`) makes this method redundant ([#471](https://github.com/bitrix24/b24phpsdk/issues/471))
 - Replaced `set*` prefix with `change*` in `Bitrix24PartnerInterface` mutator methods (`changeTitle`, `changeSite`, `changePhone`, `changeEmail`, `changeOpenLineId`, `changeExternalId`) to better express domain-level change operations ([#453](https://github.com/bitrix24/b24phpsdk/issues/453))
 - Deprecated passing `ATTACH` as raw JSON `string` to `im.message.add` and `im.message.update`; prefer `AttachPayloadInterface` for typed object payloads or raw `array` payloads for backward-compatible structures ([#426](https://github.com/bitrix24/b24phpsdk/issues/426))
 - Widened `Placement::bind()` `$options` parameter type to `PlacementOptionsInterface|array` — existing array callers remain fully compatible ([#437](https://github.com/bitrix24/b24phpsdk/issues/437))

--- a/src/Application/Contracts/Bitrix24Partners/Repository/Bitrix24PartnerRepositoryInterface.php
+++ b/src/Application/Contracts/Bitrix24Partners/Repository/Bitrix24PartnerRepositoryInterface.php
@@ -29,14 +29,6 @@ interface Bitrix24PartnerRepositoryInterface
     public function save(Bitrix24PartnerInterface $bitrix24Partner): void;
 
     /**
-     * Delete bitrix24 partner from persistence storage
-     *
-     * @throws Bitrix24PartnerNotFoundException
-     * @throws InvalidArgumentException
-     */
-    public function delete(Uuid $uuid): void;
-
-    /**
      * Get bitrix24 partner by id
      *
      * @throws Bitrix24PartnerNotFoundException

--- a/tests/Application/Contracts/Bitrix24Partners/Repository/Bitrix24PartnerRepositoryInterfaceTest.php
+++ b/tests/Application/Contracts/Bitrix24Partners/Repository/Bitrix24PartnerRepositoryInterfaceTest.php
@@ -119,39 +119,6 @@ abstract class Bitrix24PartnerRepositoryInterfaceTest extends TestCase
      */
     #[Test]
     #[DataProvider('bitrix24PartnerDataProvider')]
-    #[TestDox('test delete method')]
-    final public function testDelete(
-        Uuid                  $uuid,
-        Bitrix24PartnerStatus $bitrix24PartnerStatus,
-        string                $title,
-        ?int                  $bitrix24PartnerNumber,
-        ?string               $site,
-        ?PhoneNumber          $phoneNumber,
-        ?string               $email,
-        ?string               $openLineId,
-        ?string               $externalId,
-        string                $comment
-    ): void {
-        $b24Partner = $this->createBitrix24PartnerImplementation($uuid, $bitrix24PartnerStatus, $title, $bitrix24PartnerNumber, $site, $phoneNumber, $email, $openLineId, $externalId);
-        $b24PartnerRepository = $this->createBitrix24PartnerRepositoryImplementation();
-        $flusher = $this->createRepositoryFlusherImplementation();
-
-        $b24Partner->markAsDeleted('delete partner');
-        $b24PartnerRepository->save($b24Partner);
-        $flusher->flush();
-
-        $b24PartnerRepository->delete($b24Partner->getId());
-        $flusher->flush();
-
-        $this->assertNull($b24PartnerRepository->findByBitrix24PartnerNumber($bitrix24PartnerNumber));
-    }
-
-    /**
-     * @throws InvalidArgumentException
-     * @throws Bitrix24PartnerNotFoundException
-     */
-    #[Test]
-    #[DataProvider('bitrix24PartnerDataProvider')]
     #[TestDox('test save method')]
     final public function testGetById(
         Uuid                  $uuid,

--- a/tests/Unit/Application/Contracts/Bitrix24Partners/Repository/InMemoryBitrix24PartnerRepositoryImplementation.php
+++ b/tests/Unit/Application/Contracts/Bitrix24Partners/Repository/InMemoryBitrix24PartnerRepositoryImplementation.php
@@ -134,23 +134,6 @@ class InMemoryBitrix24PartnerRepositoryImplementation implements Bitrix24Partner
     }
 
     #[\Override]
-    public function delete(Uuid $uuid): void
-    {
-        $this->logger->debug('b24PartnerRepository.delete', ['id' => $uuid->toRfc4122()]);
-
-        $bitrix24Partner = $this->getById($uuid);
-        if (Bitrix24PartnerStatus::deleted !== $bitrix24Partner->getStatus()) {
-            throw new InvalidArgumentException(sprintf(
-                'you cannot delete bitrix24 partner item «%s», they must be in status deleted, current status «%s»',
-                $bitrix24Partner->getId()->toRfc4122(),
-                $bitrix24Partner->getStatus()->name
-            ));
-        }
-
-        unset($this->items[$uuid->toRfc4122()]);
-    }
-
-    #[\Override]
     public function getById(Uuid $uuid): Bitrix24PartnerInterface
     {
         $this->logger->debug('b24PartnerRepository.getById', ['id' => $uuid->toRfc4122()]);


### PR DESCRIPTION
| Q             | A                                                                                                                         |
|---------------|---------------------------------------------------------------------------------------------------------------------------|
| Bug fix?      | no                                                                                                                        |
| New feature?  | no                                                                                                                        |
| Deprecations? | no                                                                                                                        |
| Issues        | Fix #471                                                                                                                  |
| License       | **MIT**                                                                                                                   |

## Description

Removes the unused `delete(Uuid $uuid): void` method from `Bitrix24PartnerRepositoryInterface` and its implementations.

### Context

The `delete()` method is never invoked by any use case. The actual deletion flow uses soft-delete semantics:

1. `$partner->markAsDeleted(?string $comment)` — entity transitions to `deleted` status
2. `$repository->save($partner)` — persists the state change
3. `$flusher->flush($partner)` — flushes and dispatches domain events

The `delete()` method in the in-memory stub implementation only physically removes the entity after verifying it's already in `deleted` status, which duplicates a business invariant the entity itself enforces.

### Changes

- Removed `delete(Uuid $uuid): void` method declaration from `Bitrix24PartnerRepositoryInterface`
- Removed `delete()` implementation from `InMemoryBitrix24PartnerRepositoryImplementation`
- Removed `testDelete()` contract test method
- Updated `CHANGELOG.md`

This is a pure refactoring with no behavior change to any production use case.

### Test Plan

Existing unit and integration tests pass. The removed `testDelete()` method was the only test covering this dead code path.

https://claude.ai/code/session_01964BQ47XMfxWRzEuCSQu9S