### PR TITLE
Add IM\Department service for im.department.* methods

### DIFF
--- a/.tasks/432/plan.md
+++ b/.tasks/432/plan.md
@@ -1,0 +1,428 @@
+# Plan: Add IM\Department service for im.department.* methods (issue #432)
+
+## Context
+
+Issue #432 requests a new `Bitrix24\SDK\Services\IM\Department\Service\Department`
+service for Bitrix24 IM department REST methods.
+
+API version: v3 workstream. Base branch: `v3-dev`.
+Branch: `feature/432-add-im-department-service`.
+Worktree: `.worktrees/feature-432-add-im-department-service`.
+
+`make oa-schema-build` was run before planning and completed successfully in the main
+checkout. It was then run again inside this worktree after copying the ignored
+`tests/.env.local` file, and it also completed successfully.
+
+### REST documentation findings
+
+Bitrix24 MCP documentation was checked for each method:
+
+| Method | Parameters | Response shape | Documentation |
+|---|---|---|---|
+| `im.department.get` | required `ID` array, optional `USER_DATA` (`Y`/`N`) | `result` is a list of department objects; with `USER_DATA=Y`, each item may include `manager_user_data` | `https://apidocs.bitrix24.com/api-reference/chats/departments/im-department-get.html` |
+| `im.department.colleagues.list` | optional `USER_DATA` (`Y`/`N`), `OFFSET`, `LIMIT` | `result` is a list of user IDs when `USER_DATA=N`, or user objects when `USER_DATA=Y`; response includes `total` and optional `next` | `https://apidocs.bitrix24.com/api-reference/chats/departments/im-department-colleagues-list.html` |
+| `im.department.employees.get` | required `ID` array, optional `USER_DATA` (`Y`/`N`) | `result` is an object keyed by department ID; values are employee ID lists or user object lists | `https://apidocs.bitrix24.com/api-reference/chats/departments/im-department-employees-get.html` |
+| `im.department.managers.get` | required `ID` array, optional `USER_DATA` (`Y`/`N`) | `result` is an object keyed by department ID; values are manager ID lists or user object lists | `https://apidocs.bitrix24.com/api-reference/chats/departments/im-department-managers-get.html` |
+
+### OpenAPI and generator-first notes
+
+The refreshed `docs/open-api/openapi.json` snapshot does not contain
+`im.department.get`, `im.department.colleagues.list`, `im.department.employees.get`, or
+`im.department.managers.get`.
+
+Before manually writing `DepartmentItemResult`, run the required generator-first command:
+
+```bash
+docker compose run --rm php-cli php bin/console b24-dev:result-item-generator im.department.get --stage=all
+```
+
+If the generator cannot produce the class because the OpenAPI snapshot does not contain
+`im.department.get`, record the exact generator failure in this plan before applying the
+manual fallback. The fallback source of truth is the Bitrix24 MCP documentation plus the
+live payload checks below.
+
+Generator attempt outcome:
+
+```text
+$ docker compose run --rm php-cli php bin/console b24-dev:result-item-generator im.department.get --stage=all
+[ERROR] Unable to determine the current git branch
+```
+
+Root cause: the `php-cli` image does not contain `git`, and the generator fallback reads
+`.git/HEAD`. In this worktree `.git` is a pointer file to
+`/Users/mesilov/work/Bitrix24/b24phpsdk/.git/worktrees/feature-432-add-im-department-service`,
+which is not mounted inside the container. A read-only volume workaround also failed
+because Docker cannot mount that git metadata directory over the existing `.git` pointer
+file:
+
+```text
+error mounting ".../.git/worktrees/feature-432-add-im-department-service" to rootfs at "/var/www/html/.git": not a directory
+```
+
+Manual fallback is required for `DepartmentItemResult`.
+
+### Live playground findings
+
+Live REST probes were run against the project playground webhook:
+
+- `im.search.department.list` with `FIND=Отд`, `USER_DATA=Y`, `LIMIT=3` returned
+  department objects including departments `5` and `7`.
+- `im.department.get` with `ID=[1]`, `USER_DATA=Y` returned one department object with
+  fields `id`, `name`, `full_name`, `manager_user_id`, and `manager_user_data`.
+- `im.department.colleagues.list` with `USER_DATA=Y`, `LIMIT=3` returned user objects,
+  `total`, and `next`.
+- `im.department.employees.get` with `ID=[1]`, `USER_DATA=Y` returned an object keyed by
+  department ID with a user-object list under key `1`.
+- `im.department.managers.get` with `ID=[1]`, `USER_DATA=Y` returned an empty result on
+  the playground, so integration tests must accept an empty manager map/list.
+
+### Design options considered
+
+1. Recommended: implement a typed `Department` service with a local
+   `DepartmentItemResult`, dedicated result wrappers for department lists and user lists,
+   and reuse the existing canonical `Bitrix24\SDK\Services\IM\User\Result\UserItemResult`
+   for `USER_DATA=Y` payloads. Add ID-only helper methods for `USER_DATA=N` responses so
+   callers do not consume mixed arrays.
+2. Create a new `DepartmentUserItemResult` class. This keeps all types local to the
+   `Department` namespace but duplicates the IM user payload annotations and requires an
+   additional annotation integration test.
+3. Return raw arrays from all non-department methods. This is faster to implement but
+   gives SDK consumers weak contracts and does not match the typed IM service style.
+
+Use option 1.
+
+---
+
+## Files to Create
+
+### 1. `src/Services/IM/Department/Service/Department.php`
+
+```php
+namespace Bitrix24\SDK\Services\IM\Department\Service;
+
+#[ApiServiceMetadata(new Scope(['im']))]
+class Department extends AbstractService
+{
+    /**
+     * @param int[] $departmentIds
+     */
+    #[ApiEndpointMetadata(
+        'im.department.get',
+        'https://apidocs.bitrix24.com/api-reference/chats/departments/im-department-get.html',
+        'Get IM department data by IDs'
+    )]
+    public function get(array $departmentIds, bool $userData = false): DepartmentsResult;
+
+    #[ApiEndpointMetadata(
+        'im.department.colleagues.list',
+        'https://apidocs.bitrix24.com/api-reference/chats/departments/im-department-colleagues-list.html',
+        'List colleagues of the current user'
+    )]
+    public function colleaguesList(
+        bool $userData = false,
+        ?int $offset = null,
+        ?int $limit = null,
+    ): DepartmentUsersResult;
+
+    /**
+     * @param int[] $departmentIds
+     */
+    #[ApiEndpointMetadata(
+        'im.department.employees.get',
+        'https://apidocs.bitrix24.com/api-reference/chats/departments/im-department-employees-get.html',
+        'Get employees for IM departments'
+    )]
+    public function employeesGet(array $departmentIds, bool $userData = false): DepartmentUsersByDepartmentResult;
+
+    /**
+     * @param int[] $departmentIds
+     */
+    #[ApiEndpointMetadata(
+        'im.department.managers.get',
+        'https://apidocs.bitrix24.com/api-reference/chats/departments/im-department-managers-get.html',
+        'Get managers for IM departments'
+    )]
+    public function managersGet(array $departmentIds, bool $userData = false): DepartmentUsersByDepartmentResult;
+}
+```
+
+Payload rules:
+
+- `get()` maps `ID => $departmentIds`, `USER_DATA => 'Y'|'N'`.
+- `colleaguesList()` maps `USER_DATA => 'Y'|'N'`, and includes `OFFSET`/`LIMIT` only when
+  they are not `null`.
+- `employeesGet()` and `managersGet()` map `ID => $departmentIds`,
+  `USER_DATA => 'Y'|'N'`.
+
+### 2. `src/Services/IM/Department/Result/DepartmentItemResult.php`
+
+Create via `b24-dev:result-item-generator im.department.get --stage=all` first. If the
+generator cannot complete, manually add the class with the live/docs field set:
+
+```php
+namespace Bitrix24\SDK\Services\IM\Department\Result;
+
+use Bitrix24\SDK\Core\Result\AbstractAnnotatedItem;
+
+/**
+ * @property-read int $id
+ * @property-read string $name
+ * @property-read string $full_name
+ * @property-read int $manager_user_id
+ * @property-read array|null $manager_user_data
+ */
+class DepartmentItemResult extends AbstractAnnotatedItem
+{
+}
+```
+
+### 3. `src/Services/IM/Department/Result/DepartmentsResult.php`
+
+```php
+namespace Bitrix24\SDK\Services\IM\Department\Result;
+
+class DepartmentsResult extends AbstractResult
+{
+    /**
+     * @return DepartmentItemResult[]
+     */
+    public function items(): array;
+}
+```
+
+`items()` must read `getResponseData()->getResult()`, filter array items, and return a
+zero-based list with `array_values()`.
+
+### 4. `src/Services/IM/Department/Result/DepartmentUsersResult.php`
+
+Wraps `im.department.colleagues.list`.
+
+```php
+namespace Bitrix24\SDK\Services\IM\Department\Result;
+
+use Bitrix24\SDK\Services\IM\User\Result\UserItemResult;
+
+class DepartmentUsersResult extends AbstractResult
+{
+    /**
+     * @return int[]
+     */
+    public function userIds(): array;
+
+    /**
+     * @return UserItemResult[]
+     */
+    public function users(): array;
+
+    public function total(): int;
+
+    public function next(): ?int;
+}
+```
+
+`userIds()` filters integer result values. `users()` filters array result values and wraps
+them in `UserItemResult`.
+
+### 5. `src/Services/IM/Department/Result/DepartmentUsersByDepartmentResult.php`
+
+Wraps `im.department.employees.get` and `im.department.managers.get`.
+
+```php
+namespace Bitrix24\SDK\Services\IM\Department\Result;
+
+use Bitrix24\SDK\Services\IM\User\Result\UserItemResult;
+
+class DepartmentUsersByDepartmentResult extends AbstractResult
+{
+    /**
+     * @return array<int, int[]>
+     */
+    public function userIdsByDepartment(): array;
+
+    /**
+     * @return array<int, UserItemResult[]>
+     */
+    public function usersByDepartment(): array;
+}
+```
+
+Both methods must normalize numeric string department keys to integer keys.
+`userIdsByDepartment()` filters integer list items. `usersByDepartment()` filters array
+list items and wraps them in `UserItemResult`.
+
+### 6. `tests/Unit/Services/IM/Department/Service/DepartmentTest.php`
+
+`#[CoversClass(Department::class)]`.
+
+Test methods:
+
+- `testGetMapsDepartmentIdsAndUserDataFlag()` — asserts `im.department.get` with
+  `ID => [1, 5]`, `USER_DATA => 'Y'`, returns `DepartmentsResult`.
+- `testColleaguesListMapsUserDataAndPaginationArguments()` — asserts
+  `im.department.colleagues.list` with `USER_DATA => 'Y'`, `OFFSET`, `LIMIT`, returns
+  `DepartmentUsersResult`.
+- `testColleaguesListOmitsNullPaginationArguments()` — asserts only `USER_DATA => 'N'`.
+- `testEmployeesGetMapsDepartmentIdsAndUserDataFlag()` — asserts
+  `im.department.employees.get`.
+- `testManagersGetMapsDepartmentIdsAndUserDataFlag()` — asserts
+  `im.department.managers.get`.
+
+### 7. `tests/Integration/Services/IM/Department/Service/DepartmentTest.php`
+
+`#[CoversClass(Department::class)]`.
+
+Use `Factory::getServiceBuilder()->getIMScope()->department()`.
+
+Test methods:
+
+- `testGet()` — call `get([1], true)`, assert `DepartmentItemResult` and department ID
+  `1`; skip if the playground no longer exposes department `1`.
+- `testColleaguesList()` — call `colleaguesList(userData: true, limit: 3)`, assert
+  `users()` returns an array, `total() >= 0`, and `next()` is `null` or non-negative; if
+  users are present, assert the first item is `UserItemResult`.
+- `testEmployeesGet()` — call `employeesGet([1], true)`, assert
+  `usersByDepartment()` is an array; if department `1` has users, assert the first user is
+  `UserItemResult`.
+- `testManagersGet()` — call `managersGet([1], true)`, assert
+  `usersByDepartment()` is an array and allow an empty result.
+
+### 8. `tests/Integration/Services/IM/Department/Result/DepartmentItemResultAnnotationsTest.php`
+
+Use the repo annotation-test naming convention (`*AnnotationsTest`), even though issue
+#432 listed the file as `DepartmentItemResultTest.php`.
+
+`#[CoversClass(DepartmentItemResult::class)]`.
+
+Test methods:
+
+- `testAllSystemFieldsAnnotated()` — fetch raw first item from
+  `department()->get([1], true)->getCoreResponse()->getResponseData()->getResult()`, skip
+  if there is no department payload, and assert all raw keys are annotated.
+- `testAllSystemFieldsHasValidTypeAnnotation()` — fetch first `DepartmentItemResult` from
+  `department()->get([1], true)->items()`, skip if no item is available, and assert magic
+  getter types match annotations.
+
+---
+
+## Files to Modify
+
+### 1. `src/Services/IM/IMServiceBuilder.php`
+
+Add import:
+
+```php
+use Bitrix24\SDK\Services\IM\Department\Service\Department;
+```
+
+Add cached accessor near the other IM service accessors:
+
+```php
+public function department(): Department
+{
+    if (!isset($this->serviceCache[__METHOD__])) {
+        $this->serviceCache[__METHOD__] = new Department($this->core, $this->log);
+    }
+
+    return $this->serviceCache[__METHOD__];
+}
+```
+
+### 2. `tests/Unit/Services/IM/IMServiceBuilderTest.php`
+
+Add `Department` import and `testGetDepartmentService()` asserting:
+
+- `$this->serviceBuilder->department()` is an instance of `Department`.
+- The accessor returns the cached instance on repeated calls.
+
+### 3. `phpunit.xml.dist`
+
+Add a dedicated suite:
+
+```xml
+<testsuite name="integration_tests_im_department">
+    <directory>./tests/Integration/Services/IM/Department/</directory>
+</testsuite>
+```
+
+Place it next to the other IM suites.
+
+### 4. `Makefile`
+
+Add a help line:
+
+```makefile
+@echo "test-integration-im-department - run IM Department integration tests"
+```
+
+Add target:
+
+```makefile
+.PHONY: test-integration-im-department
+test-integration-im-department:
+	docker compose run --rm php-cli vendor/bin/phpunit --testsuite integration_tests_im_department
+```
+
+### 5. `CHANGELOG.md`
+
+After implementation and green checks, add under `## 3.2.0 – UNRELEASED` → `### Added`:
+
+```markdown
+- Added `Bitrix24\SDK\Services\IM\Department\Service\Department` service wrapping `im.department.get`, `im.department.colleagues.list`, `im.department.employees.get`, and `im.department.managers.get`, with typed department/user result wrappers and `IMServiceBuilder::department()` accessor ([#432](https://github.com/bitrix24/b24phpsdk/issues/432))
+```
+
+---
+
+## Deptrac compliance
+
+New production code stays inside the `Services` layer and depends only on:
+
+- `Core` classes (`AbstractService`, `AbstractResult`, `AbstractAnnotatedItem`, `Scope`,
+  `BaseException`, `TransportException`)
+- existing `Services\IM\User\Result\UserItemResult`
+
+The dependency is Services-to-Services inside the same layer, allowed by `deptrac.yaml`.
+Do not add entries to `deptrac.yaml` `skip_violations`.
+
+---
+
+## Verification
+
+Targeted checks during implementation:
+
+```bash
+make test-file path=tests/Unit/Services/IM/Department/Service/DepartmentTest.php
+make test-file path=tests/Unit/Services/IM/IMServiceBuilderTest.php
+make test-file path=tests/Integration/Services/IM/Department/
+```
+
+Post-implementation phase 1:
+
+```bash
+make lint-cs-fixer
+make lint-rector
+make lint-phpstan
+make lint-deptrac
+make test-unit
+```
+
+Post-implementation phase 2:
+
+```bash
+make test-integration-im-department
+```
+
+`make lint-rector` is mandatory before reporting the task as complete.
+
+---
+
+## Plan review
+
+✓ Unambiguity — every source file, test file, builder method, REST method, payload key, and
+result-wrapper method is named explicitly.
+✓ Non-contradiction — namespaces and return types are consistent across the service,
+result wrappers, builder accessor, unit tests, integration tests, Makefile target, and
+phpunit suite.
+✓ No gaps — all issue #432 acceptance criteria are covered, including docs-backed method
+mapping, generator-first ResultItem handling, builder exposure, unit tests, integration
+tests, annotation checks, Makefile/phpunit wiring, CHANGELOG, and the required quality
+gate.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 ### Added
 
+- Added `Bitrix24\SDK\Services\IM\Department\Service\Department` service wrapping `im.department.get`, `im.department.colleagues.list`, `im.department.employees.get`, and `im.department.managers.get`, with typed department/user result wrappers and `IMServiceBuilder::department()` accessor ([#432](https://github.com/bitrix24/b24phpsdk/issues/432))
 - Added `Bitrix24\SDK\Services\IM\Disk\Service\Disk` with `getFolderId(?int $chatId = null, ?string $dialogId = null)` for `im.disk.folder.get`, plus dedicated `FolderIdResult`, IM builder registration, and focused unit/integration coverage ([#435](https://github.com/bitrix24/b24phpsdk/issues/435))
 - Added `Bitrix24\SDK\Services\IM\Chat\Service\ChatUser` service wrapping `im.chat.user.add`, `im.chat.user.delete`, `im.chat.user.list` for chat participant management, with `ChatUserListResult` and `IMServiceBuilder::chatUser()` accessor ([#424](https://github.com/bitrix24/b24phpsdk/issues/424))
 - Added `Bitrix24\SDK\Services\IM\Search\Service\Search` service wrapping `im.search.chat.list`, `im.search.user.list`, `im.search.department.list`, and deprecated legacy `im.search.last.*` methods, with typed search result wrappers and `IMServiceBuilder::search()` accessor ([#431](https://github.com/bitrix24/b24phpsdk/issues/431))

--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,7 @@ help:
 	@echo "test-integration-scope-landing-template - run Landing Template integration tests"
 	@echo "test-integration-im-message - run IM Message integration tests"
 	@echo "test-integration-im-dialog - run IM Dialog integration tests"
+	@echo "test-integration-im-department - run IM Department integration tests"
 	@echo "test-integration-im-user - run IM User integration tests"
 	@echo "test-integration-im-revision - run IM Revision integration tests"
 	@echo "test-integration-im-counters - run IM Counters integration tests"
@@ -235,6 +236,10 @@ test-integration-im-chat-user:
 .PHONY: test-integration-im-dialog
 test-integration-im-dialog:
 	docker compose run --rm php-cli vendor/bin/phpunit --testsuite integration_tests_im_dialog
+
+.PHONY: test-integration-im-department
+test-integration-im-department:
+	docker compose run --rm php-cli vendor/bin/phpunit --testsuite integration_tests_im_department
 
 .PHONY: test-integration-scope-placement
 test-integration-scope-placement:

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -34,6 +34,9 @@
         <testsuite name="integration_tests_im_dialog">
             <directory>./tests/Integration/Services/IM/Dialog/</directory>
         </testsuite>
+        <testsuite name="integration_tests_im_department">
+            <directory>./tests/Integration/Services/IM/Department/</directory>
+        </testsuite>
         <testsuite name="integration_tests_im_message">
             <directory>./tests/Integration/Services/IM/Message/</directory>
         </testsuite>

--- a/src/Services/IM/Department/Result/DepartmentItemResult.php
+++ b/src/Services/IM/Department/Result/DepartmentItemResult.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * This file is part of the bitrix24-php-sdk package.
+ *
+ * © Maksim Mesilov <mesilov.maxim@gmail.com>
+ *
+ * For the full copyright and license information, please view the MIT-LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Bitrix24\SDK\Services\IM\Department\Result;
+
+use Bitrix24\SDK\Core\Result\AbstractAnnotatedItem;
+
+/**
+ * @property-read int $id
+ * @property-read string $name
+ * @property-read string $full_name
+ * @property-read int $manager_user_id
+ * @property-read array|null $manager_user_data
+ */
+class DepartmentItemResult extends AbstractAnnotatedItem
+{
+}

--- a/src/Services/IM/Department/Result/DepartmentUsersByDepartmentResult.php
+++ b/src/Services/IM/Department/Result/DepartmentUsersByDepartmentResult.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * This file is part of the bitrix24-php-sdk package.
+ *
+ * © Maksim Mesilov <mesilov.maxim@gmail.com>
+ *
+ * For the full copyright and license information, please view the MIT-LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Bitrix24\SDK\Services\IM\Department\Result;
+
+use Bitrix24\SDK\Core\Exceptions\BaseException;
+use Bitrix24\SDK\Core\Result\AbstractResult;
+use Bitrix24\SDK\Services\IM\User\Result\UserItemResult;
+
+class DepartmentUsersByDepartmentResult extends AbstractResult
+{
+    /**
+     * @return array<int, int[]>
+     * @throws BaseException
+     */
+    public function userIdsByDepartment(): array
+    {
+        $usersByDepartment = [];
+
+        foreach ($this->getCoreResponse()->getResponseData()->getResult() as $departmentId => $items) {
+            if (!is_array($items)) {
+                continue;
+            }
+
+            $usersByDepartment[(int)$departmentId] = array_values(array_filter($items, 'is_int'));
+        }
+
+        return $usersByDepartment;
+    }
+
+    /**
+     * @return array<int, UserItemResult[]>
+     * @throws BaseException
+     */
+    public function usersByDepartment(): array
+    {
+        $usersByDepartment = [];
+
+        foreach ($this->getCoreResponse()->getResponseData()->getResult() as $departmentId => $items) {
+            if (!is_array($items)) {
+                continue;
+            }
+
+            $usersByDepartment[(int)$departmentId] = array_values(array_map(
+                static fn(array $user): UserItemResult => new UserItemResult($user),
+                array_filter($items, 'is_array')
+            ));
+        }
+
+        return $usersByDepartment;
+    }
+}

--- a/src/Services/IM/Department/Result/DepartmentUsersResult.php
+++ b/src/Services/IM/Department/Result/DepartmentUsersResult.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * This file is part of the bitrix24-php-sdk package.
+ *
+ * © Maksim Mesilov <mesilov.maxim@gmail.com>
+ *
+ * For the full copyright and license information, please view the MIT-LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Bitrix24\SDK\Services\IM\Department\Result;
+
+use Bitrix24\SDK\Core\Exceptions\BaseException;
+use Bitrix24\SDK\Core\Result\AbstractResult;
+use Bitrix24\SDK\Services\IM\User\Result\UserItemResult;
+
+class DepartmentUsersResult extends AbstractResult
+{
+    /**
+     * @return int[]
+     * @throws BaseException
+     */
+    public function userIds(): array
+    {
+        return array_values(array_filter(
+            $this->getCoreResponse()->getResponseData()->getResult(),
+            'is_int'
+        ));
+    }
+
+    /**
+     * @return UserItemResult[]
+     * @throws BaseException
+     */
+    public function users(): array
+    {
+        return array_values(array_map(
+            static fn(array $user): UserItemResult => new UserItemResult($user),
+            array_filter($this->getCoreResponse()->getResponseData()->getResult(), 'is_array')
+        ));
+    }
+
+    /**
+     * @throws BaseException
+     */
+    public function total(): int
+    {
+        return $this->getCoreResponse()->getResponseData()->getPagination()->getTotal() ?? 0;
+    }
+
+    /**
+     * @throws BaseException
+     */
+    public function next(): ?int
+    {
+        return $this->getCoreResponse()->getResponseData()->getPagination()->getNextItem();
+    }
+}

--- a/src/Services/IM/Department/Result/DepartmentsResult.php
+++ b/src/Services/IM/Department/Result/DepartmentsResult.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * This file is part of the bitrix24-php-sdk package.
+ *
+ * © Maksim Mesilov <mesilov.maxim@gmail.com>
+ *
+ * For the full copyright and license information, please view the MIT-LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Bitrix24\SDK\Services\IM\Department\Result;
+
+use Bitrix24\SDK\Core\Exceptions\BaseException;
+use Bitrix24\SDK\Core\Result\AbstractResult;
+
+class DepartmentsResult extends AbstractResult
+{
+    /**
+     * @return DepartmentItemResult[]
+     * @throws BaseException
+     */
+    public function items(): array
+    {
+        return array_values(array_map(
+            static fn(array $item): DepartmentItemResult => new DepartmentItemResult($item),
+            array_filter($this->getCoreResponse()->getResponseData()->getResult(), 'is_array')
+        ));
+    }
+}

--- a/src/Services/IM/Department/Service/Department.php
+++ b/src/Services/IM/Department/Service/Department.php
@@ -1,0 +1,111 @@
+<?php
+
+/**
+ * This file is part of the bitrix24-php-sdk package.
+ *
+ * © Maksim Mesilov <mesilov.maxim@gmail.com>
+ *
+ * For the full copyright and license information, please view the MIT-LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Bitrix24\SDK\Services\IM\Department\Service;
+
+use Bitrix24\SDK\Attributes\ApiEndpointMetadata;
+use Bitrix24\SDK\Attributes\ApiServiceMetadata;
+use Bitrix24\SDK\Core\Credentials\Scope;
+use Bitrix24\SDK\Core\Exceptions\BaseException;
+use Bitrix24\SDK\Core\Exceptions\TransportException;
+use Bitrix24\SDK\Services\AbstractService;
+use Bitrix24\SDK\Services\IM\Department\Result\DepartmentsResult;
+use Bitrix24\SDK\Services\IM\Department\Result\DepartmentUsersByDepartmentResult;
+use Bitrix24\SDK\Services\IM\Department\Result\DepartmentUsersResult;
+
+#[ApiServiceMetadata(new Scope(['im']))]
+class Department extends AbstractService
+{
+    /**
+     * @param int[] $departmentIds
+     *
+     * @throws BaseException
+     * @throws TransportException
+     */
+    #[ApiEndpointMetadata(
+        'im.department.get',
+        'https://apidocs.bitrix24.com/api-reference/chats/departments/im-department-get.html',
+        'Get IM department data by IDs'
+    )]
+    public function get(array $departmentIds, bool $userData = false): DepartmentsResult
+    {
+        return new DepartmentsResult($this->core->call('im.department.get', [
+            'ID' => $departmentIds,
+            'USER_DATA' => $userData ? 'Y' : 'N',
+        ]));
+    }
+
+    /**
+     * @throws BaseException
+     * @throws TransportException
+     */
+    #[ApiEndpointMetadata(
+        'im.department.colleagues.list',
+        'https://apidocs.bitrix24.com/api-reference/chats/departments/im-department-colleagues-list.html',
+        'List colleagues of the current user'
+    )]
+    public function colleaguesList(
+        bool $userData = false,
+        ?int $offset = null,
+        ?int $limit = null,
+    ): DepartmentUsersResult {
+        $payload = [
+            'USER_DATA' => $userData ? 'Y' : 'N',
+            'OFFSET' => $offset,
+            'LIMIT' => $limit,
+        ];
+
+        return new DepartmentUsersResult($this->core->call('im.department.colleagues.list', array_filter(
+            $payload,
+            static fn(mixed $value): bool => $value !== null
+        )));
+    }
+
+    /**
+     * @param int[] $departmentIds
+     *
+     * @throws BaseException
+     * @throws TransportException
+     */
+    #[ApiEndpointMetadata(
+        'im.department.employees.get',
+        'https://apidocs.bitrix24.com/api-reference/chats/departments/im-department-employees-get.html',
+        'Get employees for IM departments'
+    )]
+    public function employeesGet(array $departmentIds, bool $userData = false): DepartmentUsersByDepartmentResult
+    {
+        return new DepartmentUsersByDepartmentResult($this->core->call('im.department.employees.get', [
+            'ID' => $departmentIds,
+            'USER_DATA' => $userData ? 'Y' : 'N',
+        ]));
+    }
+
+    /**
+     * @param int[] $departmentIds
+     *
+     * @throws BaseException
+     * @throws TransportException
+     */
+    #[ApiEndpointMetadata(
+        'im.department.managers.get',
+        'https://apidocs.bitrix24.com/api-reference/chats/departments/im-department-managers-get.html',
+        'Get managers for IM departments'
+    )]
+    public function managersGet(array $departmentIds, bool $userData = false): DepartmentUsersByDepartmentResult
+    {
+        return new DepartmentUsersByDepartmentResult($this->core->call('im.department.managers.get', [
+            'ID' => $departmentIds,
+            'USER_DATA' => $userData ? 'Y' : 'N',
+        ]));
+    }
+}

--- a/src/Services/IM/IMServiceBuilder.php
+++ b/src/Services/IM/IMServiceBuilder.php
@@ -19,6 +19,7 @@ use Bitrix24\SDK\Services\AbstractServiceBuilder;
 use Bitrix24\SDK\Services\IM\Chat\Service\Chat;
 use Bitrix24\SDK\Services\IM\Chat\Service\ChatUser;
 use Bitrix24\SDK\Services\IM\Counters\Service\Counters;
+use Bitrix24\SDK\Services\IM\Department\Service\Department;
 use Bitrix24\SDK\Services\IM\Dialog\Service\Dialog;
 use Bitrix24\SDK\Services\IM\Disk\Service\Disk;
 use Bitrix24\SDK\Services\IM\Message\Service\Message;
@@ -120,6 +121,15 @@ class IMServiceBuilder extends AbstractServiceBuilder
     {
         if (!isset($this->serviceCache[__METHOD__])) {
             $this->serviceCache[__METHOD__] = new Counters($this->core, $this->log);
+        }
+
+        return $this->serviceCache[__METHOD__];
+    }
+
+    public function department(): Department
+    {
+        if (!isset($this->serviceCache[__METHOD__])) {
+            $this->serviceCache[__METHOD__] = new Department($this->core, $this->log);
         }
 
         return $this->serviceCache[__METHOD__];

--- a/tests/Integration/Services/IM/Department/Result/DepartmentItemResultAnnotationsTest.php
+++ b/tests/Integration/Services/IM/Department/Result/DepartmentItemResultAnnotationsTest.php
@@ -1,0 +1,87 @@
+<?php
+
+/**
+ * This file is part of the bitrix24-php-sdk package.
+ *
+ * © Maksim Mesilov <mesilov.maxim@gmail.com>
+ *
+ * For the full copyright and license information, please view the MIT-LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Bitrix24\SDK\Tests\Integration\Services\IM\Department\Result;
+
+use Bitrix24\SDK\Core\Exceptions\BaseException;
+use Bitrix24\SDK\Core\Exceptions\TransportException;
+use Bitrix24\SDK\Services\IM\Department\Result\DepartmentItemResult;
+use Bitrix24\SDK\Services\IM\Department\Service\Department;
+use Bitrix24\SDK\Tests\CustomAssertions\CustomBitrix24Assertions;
+use Bitrix24\SDK\Tests\Integration\Factory;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\TestDox;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(DepartmentItemResult::class)]
+final class DepartmentItemResultAnnotationsTest extends TestCase
+{
+    use CustomBitrix24Assertions;
+
+    private Department $departmentService;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        $this->departmentService = Factory::getServiceBuilder()->getIMScope()->department();
+    }
+
+    /**
+     * @throws BaseException
+     * @throws TransportException
+     */
+    #[Test]
+    #[TestDox('all fields in DepartmentItemResult are annotated in phpdoc and match with raw api response')]
+    public function testAllSystemFieldsAnnotated(): void
+    {
+        $rawResult = $this->departmentService->get([1], true)
+            ->getCoreResponse()
+            ->getResponseData()
+            ->getResult();
+
+        if ($rawResult === []) {
+            $this->markTestSkipped('No department payload available to validate annotations');
+        }
+
+        $firstItem = reset($rawResult);
+        if (!is_array($firstItem)) {
+            $this->markTestSkipped('Unexpected response shape for im.department.get');
+        }
+
+        $this->assertBitrix24AllResultItemFieldsAnnotated(
+            array_keys($firstItem),
+            DepartmentItemResult::class
+        );
+    }
+
+    /**
+     * @throws BaseException
+     * @throws TransportException
+     */
+    #[Test]
+    #[TestDox('all fields in DepartmentItemResult have valid type casting in magic getters')]
+    public function testAllSystemFieldsHasValidTypeAnnotation(): void
+    {
+        $items = $this->departmentService->get([1], true)->items();
+
+        if ($items === []) {
+            $this->markTestSkipped('No department payload available to validate type casting');
+        }
+
+        $this->assertBitrix24ResultItemFieldsTypeCastMatchAnnotations(
+            $items[0],
+            DepartmentItemResult::class
+        );
+    }
+}

--- a/tests/Integration/Services/IM/Department/Service/DepartmentTest.php
+++ b/tests/Integration/Services/IM/Department/Service/DepartmentTest.php
@@ -1,0 +1,113 @@
+<?php
+
+/**
+ * This file is part of the bitrix24-php-sdk package.
+ *
+ * © Maksim Mesilov <mesilov.maxim@gmail.com>
+ *
+ * For the full copyright and license information, please view the MIT-LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Bitrix24\SDK\Tests\Integration\Services\IM\Department\Service;
+
+use Bitrix24\SDK\Core\Exceptions\BaseException;
+use Bitrix24\SDK\Core\Exceptions\TransportException;
+use Bitrix24\SDK\Services\IM\Department\Result\DepartmentItemResult;
+use Bitrix24\SDK\Services\IM\Department\Service\Department;
+use Bitrix24\SDK\Services\IM\User\Result\UserItemResult;
+use Bitrix24\SDK\Tests\Integration\Factory;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\TestDox;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(Department::class)]
+final class DepartmentTest extends TestCase
+{
+    private Department $departmentService;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        $this->departmentService = Factory::getServiceBuilder()->getIMScope()->department();
+    }
+
+    /**
+     * @throws BaseException
+     * @throws TransportException
+     */
+    #[Test]
+    #[TestDox('im.department.get returns a list of DepartmentItemResult')]
+    public function testGet(): void
+    {
+        $items = $this->departmentService->get([1], true)->items();
+
+        if ($items === []) {
+            $this->markTestSkipped('No department 1 payload available for im.department.get');
+        }
+
+        $this->assertInstanceOf(DepartmentItemResult::class, $items[0]);
+        $this->assertSame(1, $items[0]->id);
+    }
+
+    /**
+     * @throws BaseException
+     * @throws TransportException
+     */
+    #[Test]
+    #[TestDox('im.department.colleagues.list returns a paginated list of UserItemResult')]
+    public function testColleaguesList(): void
+    {
+        $departmentUsersResult = $this->departmentService->colleaguesList(userData: true, limit: 3);
+        $users = $departmentUsersResult->users();
+
+        $this->assertIsArray($users);
+        $this->assertGreaterThanOrEqual(0, $departmentUsersResult->total());
+        $this->assertTrue($departmentUsersResult->next() === null || $departmentUsersResult->next() >= 0);
+
+        if ($users === []) {
+            $this->markTestSkipped('No colleagues available for im.department.colleagues.list');
+        }
+
+        $this->assertInstanceOf(UserItemResult::class, $users[0]);
+    }
+
+    /**
+     * @throws BaseException
+     * @throws TransportException
+     */
+    #[Test]
+    #[TestDox('im.department.employees.get returns users grouped by department ID')]
+    public function testEmployeesGet(): void
+    {
+        $usersByDepartment = $this->departmentService->employeesGet([1], true)->usersByDepartment();
+
+        $this->assertIsArray($usersByDepartment);
+
+        if (($usersByDepartment[1] ?? []) === []) {
+            $this->markTestSkipped('No users available in department 1 for im.department.employees.get');
+        }
+
+        $this->assertInstanceOf(UserItemResult::class, $usersByDepartment[1][0]);
+    }
+
+    /**
+     * @throws BaseException
+     * @throws TransportException
+     */
+    #[Test]
+    #[TestDox('im.department.managers.get returns users grouped by department ID or an empty result')]
+    public function testManagersGet(): void
+    {
+        $usersByDepartment = $this->departmentService->managersGet([1], true)->usersByDepartment();
+
+        $this->assertIsArray($usersByDepartment);
+
+        if (($usersByDepartment[1] ?? []) !== []) {
+            $this->assertInstanceOf(UserItemResult::class, $usersByDepartment[1][0]);
+        }
+    }
+}

--- a/tests/Unit/Services/IM/Department/Service/DepartmentTest.php
+++ b/tests/Unit/Services/IM/Department/Service/DepartmentTest.php
@@ -1,0 +1,136 @@
+<?php
+
+/**
+ * This file is part of the bitrix24-php-sdk package.
+ *
+ * © Maksim Mesilov <mesilov.maxim@gmail.com>
+ *
+ * For the full copyright and license information, please view the MIT-LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Bitrix24\SDK\Tests\Unit\Services\IM\Department\Service;
+
+use Bitrix24\SDK\Core\Contracts\CoreInterface;
+use Bitrix24\SDK\Core\Response\Response;
+use Bitrix24\SDK\Services\IM\Department\Result\DepartmentsResult;
+use Bitrix24\SDK\Services\IM\Department\Result\DepartmentUsersByDepartmentResult;
+use Bitrix24\SDK\Services\IM\Department\Result\DepartmentUsersResult;
+use Bitrix24\SDK\Services\IM\Department\Service\Department;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+#[CoversClass(Department::class)]
+final class DepartmentTest extends TestCase
+{
+    private Department $service;
+
+    private CoreInterface&MockObject $coreMock;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        $this->coreMock = $this->createMock(CoreInterface::class);
+        $this->service = new Department($this->coreMock, new NullLogger());
+    }
+
+    #[Test]
+    public function testGetMapsDepartmentIdsAndUserDataFlag(): void
+    {
+        $response = $this->createStub(Response::class);
+
+        $this->coreMock
+            ->expects($this->once())
+            ->method('call')
+            ->with('im.department.get', [
+                'ID' => [1, 5],
+                'USER_DATA' => 'Y',
+            ])
+            ->willReturn($response);
+
+        $departmentsResult = $this->service->get([1, 5], true);
+
+        self::assertInstanceOf(DepartmentsResult::class, $departmentsResult);
+    }
+
+    #[Test]
+    public function testColleaguesListMapsUserDataAndPaginationArguments(): void
+    {
+        $response = $this->createStub(Response::class);
+
+        $this->coreMock
+            ->expects($this->once())
+            ->method('call')
+            ->with('im.department.colleagues.list', [
+                'USER_DATA' => 'Y',
+                'OFFSET' => 10,
+                'LIMIT' => 25,
+            ])
+            ->willReturn($response);
+
+        $departmentUsersResult = $this->service->colleaguesList(true, 10, 25);
+
+        self::assertInstanceOf(DepartmentUsersResult::class, $departmentUsersResult);
+    }
+
+    #[Test]
+    public function testColleaguesListOmitsNullPaginationArguments(): void
+    {
+        $response = $this->createStub(Response::class);
+
+        $this->coreMock
+            ->expects($this->once())
+            ->method('call')
+            ->with('im.department.colleagues.list', [
+                'USER_DATA' => 'N',
+            ])
+            ->willReturn($response);
+
+        $departmentUsersResult = $this->service->colleaguesList();
+
+        self::assertInstanceOf(DepartmentUsersResult::class, $departmentUsersResult);
+    }
+
+    #[Test]
+    public function testEmployeesGetMapsDepartmentIdsAndUserDataFlag(): void
+    {
+        $response = $this->createStub(Response::class);
+
+        $this->coreMock
+            ->expects($this->once())
+            ->method('call')
+            ->with('im.department.employees.get', [
+                'ID' => [1, 5],
+                'USER_DATA' => 'Y',
+            ])
+            ->willReturn($response);
+
+        $departmentUsersByDepartmentResult = $this->service->employeesGet([1, 5], true);
+
+        self::assertInstanceOf(DepartmentUsersByDepartmentResult::class, $departmentUsersByDepartmentResult);
+    }
+
+    #[Test]
+    public function testManagersGetMapsDepartmentIdsAndUserDataFlag(): void
+    {
+        $response = $this->createStub(Response::class);
+
+        $this->coreMock
+            ->expects($this->once())
+            ->method('call')
+            ->with('im.department.managers.get', [
+                'ID' => [1, 5],
+                'USER_DATA' => 'N',
+            ])
+            ->willReturn($response);
+
+        $departmentUsersByDepartmentResult = $this->service->managersGet([1, 5]);
+
+        self::assertInstanceOf(DepartmentUsersByDepartmentResult::class, $departmentUsersByDepartmentResult);
+    }
+}

--- a/tests/Unit/Services/IM/IMServiceBuilderTest.php
+++ b/tests/Unit/Services/IM/IMServiceBuilderTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Bitrix24\SDK\Tests\Unit\Services\IM;
 
 use Bitrix24\SDK\Services\IM\Counters\Service\Counters;
+use Bitrix24\SDK\Services\IM\Department\Service\Department;
 use Bitrix24\SDK\Services\IM\Dialog\Service\Dialog;
 use Bitrix24\SDK\Services\IM\Disk\Service\Disk;
 use Bitrix24\SDK\Services\IM\IMServiceBuilder;
@@ -76,6 +77,12 @@ class IMServiceBuilderTest extends TestCase
     {
         $this->assertInstanceOf(Counters::class, $this->serviceBuilder->counters());
         $this->assertSame($this->serviceBuilder->counters(), $this->serviceBuilder->counters());
+    }
+
+    public function testGetDepartmentService(): void
+    {
+        $this->assertInstanceOf(Department::class, $this->serviceBuilder->department());
+        $this->assertSame($this->serviceBuilder->department(), $this->serviceBuilder->department());
     }
 
     public function testGetUserStatusService(): void


### PR DESCRIPTION
| Q             | A                                                                                                                         |
|---------------|---------------------------------------------------------------------------------------------------------------------------|
| Bug fix?      | no                                                                                                                        |
| New feature?  | yes                                                                                                                       |
| Deprecations? | no                                                                                                                        |
| Issues        | Fix #432                                                                                                                  |
| License       | **MIT**                                                                                                                   |

Adds `Bitrix24\SDK\Services\IM\Department\Service\Department` for the `im.department.*` REST methods that are not present in the local OpenAPI snapshot yet.

Implemented methods:
- `get(array $departmentIds, bool $userData = false)` for `im.department.get`
- `colleaguesList(bool $userData = false, ?int $offset = null, ?int $limit = null)` for `im.department.colleagues.list`
- `employeesGet(array $departmentIds, bool $userData = false)` for `im.department.employees.get`
- `managersGet(array $departmentIds, bool $userData = false)` for `im.department.managers.get`

The new service is available through `Factory::getServiceBuilder()->getIMScope()->department()` and returns typed wrappers for department items, colleague lists, and user lists grouped by department id.

```php
$departmentService = Factory::getServiceBuilder()->getIMScope()->department();

$departments = $departmentService->get([1], true)->items();
$colleagues = $departmentService->colleaguesList(true, limit: 50)->users();
$employeesByDepartment = $departmentService->employeesGet([1], true)->usersByDepartment();
$managersByDepartment = $departmentService->managersGet([1], true)->usersByDepartment();
```

## Test plan

- [x] `make oa-schema-build` — passed
- [x] `make lint-cs-fixer` — passed
- [x] `make lint-rector` — passed
- [x] `make lint-phpstan` — passed
- [x] `make lint-deptrac` — passed
- [x] `make test-unit` — passed: `OK (918 tests, 2581 assertions)`
- [x] `make test-integration-im-department` — passed: `OK (6 tests, 16 assertions)`

Closes #432

🤖 Generated with [Claude Code](https://claude.ai/claude-code)