### PR TITLE
fix: rename 'en' to 'ent' (Enterprise) in PortalLicenseFamily enum

### DIFF
--- a/src/Application/PortalLicenseFamily.php
+++ b/src/Application/PortalLicenseFamily.php
@@ -25,6 +25,6 @@ enum PortalLicenseFamily: string
     case std = 'std';
     case pro = 'pro';
     case project = 'project';
-    case en = 'en';
+    case ent = 'ent';
     case nfr = 'nfr';
 }

--- a/tests/Application/Contracts/ApplicationInstallations/Entity/ApplicationInstallationInterfaceTest.php
+++ b/tests/Application/Contracts/ApplicationInstallations/Entity/ApplicationInstallationInterfaceTest.php
@@ -756,7 +756,7 @@ abstract class ApplicationInstallationInterfaceTest extends TestCase
         );
         $this->assertEquals($portalLicenseFamily, $installation->getPortalLicenseFamily());
 
-        $newLicenseFamily = PortalLicenseFamily::en;
+        $newLicenseFamily = PortalLicenseFamily::ent;
         $installation->changePortalLicenseFamily($newLicenseFamily);
         $this->assertEquals($newLicenseFamily, $installation->getPortalLicenseFamily());
     }


### PR DESCRIPTION
## Problem

Bitrix24 portals with Enterprise license return `LICENSE_FAMILY = 'ent'` from `app.info` REST API response. This causes:

```
"ent" is not a valid backing value for enum Bitrix24\SDK\Application\PortalLicenseFamily
```

## Fix

Rename `en` → `ent` in `PortalLicenseFamily` enum. The `en` value was a typo — Bitrix24 API returns `ent` for Enterprise portals.

Reference: https://apidocs.bitrix24.com/api-reference/common/system/app-info.html

## Changes

- `src/Application/PortalLicenseFamily.php`: `case en = 'en'` → `case ent = 'ent'`
- `tests/.../ApplicationInstallationInterfaceTest.php`: updated reference accordingly
