### PR TITLE
Fix README examples that referenced non-existent folders

### DIFF
--- a/.tasks/474/plan.md
+++ b/.tasks/474/plan.md
@@ -1,0 +1,49 @@
+# Plan: Fix broken /examples/* references in README (issue #474)
+
+## Context
+
+Issue #474 reports that `README.md` tells the reader to "Go to `/examples/webhook` folder" and
+"Go to `/examples/local-app` folder", but no `examples/` directory exists in the repository, so the
+instructions cannot be followed.
+
+Findings:
+- `README.md:146` — `1. Go to `/examples/webhook` folder`
+- `README.md:181` — `1. Go to `/examples/local-app` folder`
+- No `examples/` directory exists.
+- A complete, runnable local-application reference already exists in `tests/ApplicationBridge/`
+  (`index.php`, `install.php`, token storage, credentials provider).
+
+Decision (brainstormed, option B): documentation-only fix — make the README instructions
+self-contained instead of pointing to non-existent folders. Do NOT create new `examples/` dirs.
+
+Base branch: `v3-dev` (milestone 3.3.0; examples use the v3 `ServiceBuilderFactory` API).
+
+## Files to Modify
+
+### 1. `README.md` — "Work with webhook" section (~144-177)
+- Replace step "Go to `/examples/webhook` folder" + `composer install` with installing the SDK via
+  `composer require bitrix24/b24phpsdk`.
+- Renumber the remaining steps; keep the existing inline code snippet (add a `<?php` opening tag so
+  the file is runnable). Run step becomes `php -f webhook-example.php`.
+
+### 2. `README.md` — "Work with local application" section (~179-253)
+- Replace step "Go to `/examples/local-app` folder" + `composer install` with installing the SDK via
+  `composer require bitrix24/b24phpsdk`.
+- Add a sentence pointing to `tests/ApplicationBridge/` as a complete runnable reference
+  implementation.
+- Keep the rest of the section unchanged (ngrok, creating the local app, the `index.php` snippet).
+
+### 3. `CHANGELOG.md` (under `## 3.3.0 – UNRELEASED` → `### Changed`)
+- `- Fixed README "Examples" section that pointed to non-existent `/examples/webhook` and
+  `/examples/local-app` folders; instructions are now self-contained and reference
+  `tests/ApplicationBridge` for the local application ([#474](https://github.com/bitrix24/b24phpsdk/issues/474))`
+  (place under `### Fixed`).
+
+## Out of scope
+- No new `examples/` directories or example code files.
+- No source code changes.
+
+## Verification
+- `grep -n "/examples/" README.md` returns nothing.
+- Manual read-through of both sections for correct numbering and valid fenced code blocks.
+- (No code touched → unit/lint suites unaffected; documentation change only.)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,9 @@
 
 ### Fixed
 
+- Fixed README "Examples" section that pointed to non-existent `/examples/webhook` and
+  `/examples/local-app` folders; instructions are now self-contained and reference
+  `tests/ApplicationBridge` for the local application ([#474](https://github.com/bitrix24/b24phpsdk/issues/474))
 - Fixed malformed `event_type` request parameter key (it contained a tab character, so the value
   never reached the API) in `Services\Main\Service\Event::bind()` and `unbind()` ([#386](https://github.com/bitrix24/b24phpsdk/issues/386))
 

--- a/README.md
+++ b/README.md
@@ -143,17 +143,18 @@ Performance improvements 🚀
 
 ### Work with webhook
 
-1. Go to `/examples/webhook` folder
-2. Open console and install dependencies
+1. Install the SDK into your project:
 
 ```shell
-composer install
+composer require bitrix24/b24phpsdk
 ```
 
-3. Open Bitrix24 account: Developer resources → Other → Inbound webhook
-4. Open example file and insert webhook url into `$webhookUrl`
+2. Open Bitrix24 account: Developer resources → Other → Inbound webhook
+3. Create a PHP file (for example `webhook-example.php`) and insert your webhook url into `$webhookUrl`:
 
 ```php
+<?php
+
 declare(strict_types=1);
 
 use Bitrix24\SDK\Services\ServiceBuilderFactory;
@@ -167,38 +168,40 @@ $b24Service = ServiceBuilderFactory::createServiceBuilderFromWebhook('INSERT_HER
 var_dump($b24Service->getMainScope()->main()->getApplicationInfo()->applicationInfo());
 // call core for method in not implemented service
 var_dump($b24Service->core->call('user.current'));
-
 ```
 
-5. Call php file in shell
+4. Call php file in shell
 
 ```shell
-php -f example.php
+php -f webhook-example.php
 ```
 
 ### Work with local application
 
-1. Go to `/examples/local-app` folder
-2. Open console and install dependencies
+A complete, runnable local-application example (`index.php`, `install.php`, OAuth token storage and
+credentials provider) is available in [`tests/ApplicationBridge`](tests/ApplicationBridge) — use it
+as a reference implementation.
+
+1. Install the SDK into your project:
 
 ```shell
-composer install
+composer require bitrix24/b24phpsdk
 ```
 
-3. Start local development server
+2. Start local development server
 
 ```shell
 sudo php -S 127.0.0.1:80
 ```
 
-4. Expose local server to public via [ngrok](https://ngrok.com/) and remember temporally public url –
+3. Expose local server to public via [ngrok](https://ngrok.com/) and remember temporally public url –
    `https://****.ngrok-free.app`
 
 ```shell
 ngrok http 127.0.0.1
 ```
 
-5. Check public url from ngrok and see `x-powered-by` header with **200** status-code.
+4. Check public url from ngrok and see `x-powered-by` header with **200** status-code.
 
 ```shell
 curl https://****.ngrok-free.app -I
@@ -209,13 +212,13 @@ host: ****.ngrok-free.app
 x-powered-by: PHP/8.3.8
 ```
 
-6. Open Bitrix24 account: Developer resources → Other → Local application and create new local application:
+5. Open Bitrix24 account: Developer resources → Other → Local application and create new local application:
     - `type`: server
     - `handler path`: `https://****.ngrok-free.app/index.php`
     - `Initial installation path`: `https://****.ngrok-free.app/install.php`
     - `Menu item text`: `Test local app`
     - `scope`: `crm`
-7. Save application parameters in `index.php` file:
+6. Save application parameters in `index.php` file:
     - `Application ID (client_id)` — `BITRIX24_PHP_SDK_APPLICATION_CLIENT_ID`
     - `Application key (client_secret)` — `BITRIX24_PHP_SDK_APPLICATION_CLIENT_SECRET`
     - `Assing permitions (scope)` — `BITRIX24_PHP_SDK_APPLICATION_SCOPE`
@@ -250,7 +253,7 @@ var_dump($b24Service->getMainScope()->main()->getCurrentUserProfile()->getUserPr
 ```
 
 </details>
-8. Save local application in Bitrix24 tab and press «OPEN APPLICATION» button.    
+7. Save local application in Bitrix24 tab and press «OPEN APPLICATION» button.    
 
 ### Create application for Bitrix24 marketplace
 


### PR DESCRIPTION
| Q             | A          |
|---------------|------------|
| Bug fix?      | yes        |
| New feature?  | no         |
| Deprecations? | no         |
| Issues        | Fix #474   |
| License       | **MIT**    |

## What & why

Issue #474 reports that the README "Examples" section tells the reader to "Go to `/examples/webhook` folder" and "Go to `/examples/local-app` folder", but no `examples/` directory exists in the repository, so the instructions cannot be followed.

This is a documentation-only fix (no `examples/` directories are added):

- **Work with webhook** — replaced the "go to folder" + `composer install` steps with installing the SDK via `composer require bitrix24/b24phpsdk`; the inline snippet now opens with `<?php` so it is a runnable file, and steps are renumbered.
- **Work with local application** — same `composer require` step, and the section now points to [`tests/ApplicationBridge`](tests/ApplicationBridge) as a complete, runnable reference implementation (`index.php`, `install.php`, OAuth token storage, credentials provider). Remaining steps renumbered.

No source code is touched.

## Test plan

Documentation-only change — the PHP lint/test suites do not apply (no `.php` files changed). Verified manually:

- [x] `grep -n "/examples/" README.md` returns nothing (both broken references removed)
- [x] step numbering in both "Examples" sub-sections is sequential
- [x] `CHANGELOG.md` updated under `### Fixed`

Closes #474

🤖 Generated with [Claude Code](https://claude.com/claude-code)