### PR TITLE
Remove duplicate Booking entry from 3.4.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@
     - `getList` gets the list of widgets for the current application
     - `debug` enables or disables debug mode for all widgets of the current application
 - Added `repoWidget()` accessor to `LandingServiceBuilder` ([#501](https://github.com/bitrix24/b24phpsdk/issues/501))
-- Added service `Services\Booking\BookingServiceBuilder` with Booking scope wrappers and integration coverage for `booking.v1.clienttype.*`, `booking.v1.resourceType.*`, `booking.v1.resource.*`, `booking.v1.resource.slots.*`, `booking.v1.waitlist.*`, `booking.v1.waitlist.client.*`, `booking.v1.waitlist.externalData.*`, `booking.v1.booking.*`, `booking.v1.booking.client.*`, and `booking.v1.booking.externalData.*` methods.
 
 ### Changed
 


### PR DESCRIPTION
| Q             | A   |
|---------------|-----|
| Bug fix?      | yes |
| New feature?  | no  |
| Deprecations? | no  |
| Issues        | n/a |
| License       | **MIT** |

Cleanup of a `CHANGELOG.md` merge artifact on `v3-dev`.

When PR #506 (landing.repowidget v3, #501) was merged, it carried the Booking entry from its stale base (where the top section was `## 3.3.0 – UNRELEASED`) into the new `## 3.4.0 – UNRELEASED` section — duplicating the Booking feature that was already finalized under `## 3.3.0` (with its `#473` issue link).

This removes the stray duplicate so:

- `## 3.4.0` lists only the landing.repowidget (#501) feature.
- Booking stays documented once, under released `## 3.3.0` (with `#473`).

No code changes — `CHANGELOG.md` only.

## Test plan

- [x] `make lint-rector` — passed

🤖 Generated with [Claude Code](https://claude.ai/claude-code)