### PR TITLE
Ship SDK release 3.4.0

### DIFF
--- a/.tasks/541/plan.md
+++ b/.tasks/541/plan.md
@@ -1,0 +1,87 @@
+# Plan: Shipping new SDK release 3.4.0 (issue #541)
+
+## Context
+
+Issue [#541](https://github.com/bitrix24/b24phpsdk/issues/541) is a release-engineering
+checklist for shipping SDK version **3.4.0** (the 3.x line → base branch `v3-dev`).
+No REST API methods are involved, so the API-documentation research step and the
+brainstorming step are intentionally skipped: the issue body is a fixed checklist with
+no design space.
+
+Issue checklist state at start of work:
+
+- [ ] write release notes documentation in the changelog.MD — the `## 3.4.0` section was
+  already tidied against milestone 3.4.0 (deduplicated Booking entry that shipped in 3.3.0,
+  added missing entry for PR #532, expanded the Mail #516 entry); the tidy-up is sitting
+  uncommitted in the working tree and will be committed in this branch. Remaining work:
+  replace the `UNRELEASED` marker with the release date.
+- [ ] update version in all code examples in main README.md — the only 3.x version
+  reference is the composer constraint on line 50.
+- [ ] update the version in headers in `/src/Core/ApiClient.php` — `SDK_VERSION` const on
+  line 40 (used for `User-Agent` and `X-BITRIX24-PHP-SDK-VERSION` headers).
+- [ ] local pass phpstan linter
+- [ ] local pass rector linter
+- [ ] local pass PHPUnit tests
+- [x] pass all integration tests by scope — already checked off in the issue.
+
+No test pins the SDK version string, so bumping `SDK_VERSION` cannot break the unit suite.
+
+---
+
+## Files to Create
+
+None (only this plan file).
+
+---
+
+## Files to Modify
+
+### 1. `CHANGELOG.md`
+
+- Change heading `## 3.4.0 – UNRELEASED` → `## 3.4.0 - 2026.07.19`
+  (date style follows the existing `## 3.0.0 - 2026.02.27` entry).
+- Commit the already-prepared 3.4.0 section tidy-up (currently uncommitted).
+
+### 2. `README.md`
+
+- Line 50: `composer require bitrix24/b24phpsdk:"^3.3"` → `composer require bitrix24/b24phpsdk:"^3.4"`.
+- Line 44 (`^1.0`) belongs to the 1.x line and stays unchanged.
+
+### 3. `src/Core/ApiClient.php`
+
+- Line 40: `protected const string SDK_VERSION = '3.3.0';` → `'3.4.0'`.
+
+---
+
+## Out of scope
+
+- `docs/open-api/openapi.json` — modified as a side effect of the mandatory
+  `make oa-schema-build` skill step; not part of the release checklist, left uncommitted.
+- Untracked `.ai/` and `docs/open-api/v3-uncovered-methods.md` — not part of the release.
+- Creating the git tag / GitHub release — not in the issue checklist; done by the
+  maintainer after the PR merges.
+
+---
+
+## Deptrac compliance
+
+No imports are added or changed; the change set is version strings and documentation.
+No new layer violations are possible.
+
+---
+
+## Verification
+
+```bash
+make lint-cs-fixer
+make lint-rector
+make lint-phpstan
+make lint-deptrac
+make test-unit
+```
+
+Integration tests by scope are already marked as passed in the issue and are not re-run.
+
+After the quality gate is green: commit, push `feature/541-shipping-release-3-4-0`,
+open a PR against `v3-dev` using `.github/PULL_REQUEST_TEMPLATE.md`, milestone `3.4.0`,
+with `Closes #541`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # b24-php-sdk change log
-## 3.4.0 – UNRELEASED
+## 3.4.0
 
 ### Added
 
@@ -74,9 +74,13 @@
     - `delete` deletes a mail service, with batch calls support
     - `fields` returns localized field labels of a mail service
     - `count` counts active mail services
-- Added REST API v3 `Services\Mail` scope wrappers for `mail.*` mailbox, message, recipient,
-  and field metadata methods ([#516](https://github.com/bitrix24/b24phpsdk/issues/516))
-- Added `Services\Booking\BookingServiceBuilder` with Booking scope wrappers and integration coverage for `booking.v1.clienttype.*`, `booking.v1.resourceType.*`, `booking.v1.resource.*`, `booking.v1.resource.slots.*`, `booking.v1.waitlist.*`, `booking.v1.waitlist.client.*`, `booking.v1.waitlist.externalData.*`, `booking.v1.booking.*`, `booking.v1.booking.client.*`, and `booking.v1.booking.externalData.*` methods.
+- Added REST API v3 scope `Services\Mail` with `Mailbox`, `Message`, and `Recipient` services and
+  dedicated `MailboxField`, `MessageField`, and `RecipientField` field metadata services ([#516](https://github.com/bitrix24/b24phpsdk/issues/516)):
+    - `Mailbox`: `list`, `get`, `senders`, with batch calls support
+    - `Message`: `list`, `get`, `send`, `reply`, `forward`, `thread`, `moveToFolder`, `createCalendarEvent`,
+      `createChat`, `createCrmActivity`, `removeCrmActivity`, `createFeedPost`, `createTask`, with batch calls support
+    - `Recipient`: `listContacts`, `listEmployees`, with batch calls support
+    - field metadata services cover `mail.mailbox.field.*`, `mail.message.field.*`, and `mail.recipient.field.*`
 - Added service `Services\Messageservice\Sender` and `Services\Messageservice\Message\Status` with support for `messageservice.*` methods,
   see [messageservice.* methods](https://apidocs.bitrix24.com/api-reference/messageservice/index.html) ([#498](https://github.com/bitrix24/b24phpsdk/issues/498)):
     - `sender.add` — register a new SMS message service provider
@@ -84,7 +88,6 @@
     - `sender.list` — get list of sender codes registered by the current application
     - `sender.delete` — delete a registered message service provider
     - `message.status.update` — update delivery status of a message sent via a provider
-- Added `Services\Booking\BookingServiceBuilder` with Booking scope wrappers and integration coverage for `booking.v1.clienttype.*`, `booking.v1.resourceType.*`, `booking.v1.resource.*`, `booking.v1.resource.slots.*`, `booking.v1.waitlist.*`, `booking.v1.waitlist.client.*`, `booking.v1.waitlist.externalData.*`, `booking.v1.booking.*`, `booking.v1.booking.client.*`, and `booking.v1.booking.externalData.*` methods.
 - Added service `Services\Landing\RepoWidget` with support for Vibe widget management,
   see [landing.repowidget.* methods](https://apidocs.bitrix24.com/api-reference/vibe/index.html)
   ([#501](https://github.com/bitrix24/b24phpsdk/issues/501)):
@@ -118,6 +121,8 @@
 - Fixed `Application\PortalLicenseFamily` enum throwing `"ent" is not a valid backing value` for
   Enterprise portals: Bitrix24 `app.info` returns `LICENSE_FAMILY = 'ent'`, but the enum had a typo
   `en`; renamed `en` → `ent` ([#500](https://github.com/bitrix24/b24phpsdk/pull/500))
+- Fixed malformed `testsuite` tag in `phpunit.xml.dist` (missing closing tag introduced by a merge) that made
+  the config invalid XML and prevented the whole unit suite from running on `v3-dev` ([#532](https://github.com/bitrix24/b24phpsdk/pull/532))
 
 ## 3.3.0
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ composer require bitrix24/b24phpsdk:"^1.0"
 Install the new v3 version (PHP 8.4+, breaking changes):
 
 ```bash
-composer require bitrix24/b24phpsdk:"^3.3"
+composer require bitrix24/b24phpsdk:"^3.4"
 ```
 
 If you work on Windows:

--- a/src/Core/ApiClient.php
+++ b/src/Core/ApiClient.php
@@ -37,7 +37,7 @@ class ApiClient implements ApiClientInterface
     /**
      * @const string
      */
-    protected const string SDK_VERSION = '3.3.0';
+    protected const string SDK_VERSION = '3.4.0';
 
     protected const string SDK_USER_AGENT = 'b24-php-sdk-vendor';
 


### PR DESCRIPTION
| Q             | A                          |
|---------------|----------------------------|
| Bug fix?      | no                         |
| New feature?  | no                         |
| Deprecations? | no                         |
| Issues        | Fix #541                   |
| License       | **MIT**                    |

Release chores for shipping SDK version **3.4.0**:

- **CHANGELOG.md** — finalized the 3.4.0 release notes against milestone 3.4.0:
  - removed the duplicated Booking scope entry (Booking shipped in 3.3.0, see #473)
  - added the missing `### Fixed` entry for the malformed `phpunit.xml.dist` testsuite tag (#532)
  - expanded the Mail scope entry (#516) with the `Mailbox` / `Message` / `Recipient` services,
    their methods, and the dedicated field metadata services
  - dropped the `UNRELEASED` marker from the section heading
- **README.md** — bumped the v3 install constraint: `composer require bitrix24/b24phpsdk:"^3.4"`
- **src/Core/ApiClient.php** — bumped `SDK_VERSION` to `3.4.0` (used in `User-Agent`
  and `X-BITRIX24-PHP-SDK-VERSION` request headers)
- added the task plan `.tasks/541/plan.md`

## Test plan

- [x] `make lint-cs-fixer` — passed
- [x] `make lint-rector` — passed
- [x] `make lint-phpstan` — passed
- [x] `make lint-deptrac` — passed
- [x] `make test-unit` — passed, OK (1108 tests, 3094 assertions)
- [x] integration tests by scope — marked as passed in the issue checklist

Closes #541

🤖 Generated with [Claude Code](https://claude.com/claude-code)