### PR TITLE
Add Bitrix24 SDK developer skill

### DIFF
--- a/.agents/skills/b24phpsdk-developer/SKILL.md
+++ b/.agents/skills/b24phpsdk-developer/SKILL.md
@@ -1,0 +1,13 @@
+---
+name: b24phpsdk-developer
+description: Use when writing product application code with bitrix24/b24phpsdk, integrating Bitrix24 webhooks or OAuth, choosing SDK service calls, handling SDK results, errors, pagination, batch calls, or tests outside the SDK repository
+---
+
+# Bitrix24 PHP SDK Developer Loader
+
+Read the canonical project skill before acting:
+
+`resources/skills/b24phpsdk-developer/SKILL.md`
+
+That file is the source of truth for product application guidance. This loader exists so Codex can
+discover the skill while working inside this SDK repository.

--- a/.claude/skills/b24phpsdk-developer/SKILL.md
+++ b/.claude/skills/b24phpsdk-developer/SKILL.md
@@ -1,0 +1,13 @@
+---
+name: b24phpsdk-developer
+description: Use when writing product application code with bitrix24/b24phpsdk, integrating Bitrix24 webhooks or OAuth, choosing SDK service calls, handling SDK results, errors, pagination, batch calls, or tests outside the SDK repository
+---
+
+# Bitrix24 PHP SDK Developer Loader
+
+Read the canonical project skill before acting:
+
+`resources/skills/b24phpsdk-developer/SKILL.md`
+
+That file is the source of truth for product application guidance. This loader exists so Claude Code
+can discover the skill while working inside this SDK repository.

--- a/.tasks/562/plan.md
+++ b/.tasks/562/plan.md
@@ -1,0 +1,366 @@
+# Plan: Add Bitrix24 SDK Developer Skill (issue #562)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:test-driven-development for
+> production-code changes and use superpowers:writing-skills for the skill-documentation
+> RED-GREEN-REFACTOR loop. Track this plan with checkbox syntax.
+
+**Goal:** add a distributable `b24phpsdk-developer` skill that teaches product teams how to use
+`bitrix24/b24phpsdk` correctly in their own applications.
+
+**Architecture:** keep the canonical distributable skill under `resources/skills/` and expose it
+through the `llm/skills` Composer donor contract. Add small repo-local loader skills for Claude Code
+and Codex so the same canonical guidance is available while working in this repository without
+accidentally distributing the maintainer workflow skill.
+
+**Tech Stack:** Markdown skill files, Composer package metadata, `llm/skills`, Claude Code project
+skills, Codex project skills, PHP CLI smoke project, `bitrix24/b24phpsdk`.
+
+---
+
+## Context
+
+Issue #562 requests a separate Bitrix24 SDK developer skill for product application developers.
+The existing `.claude/skills/b24phpsdk-maintainer` skill remains scoped to SDK repository
+maintenance: GitHub issues, PRs, release workflow, REST method research, changelog rules, and SDK
+internals. The new skill must not replace or be distributed together with that maintainer workflow.
+
+This issue does not add SDK service PHP classes, result items, select builders, or item builders.
+The SDK code generators listed in `.claude/skills/b24phpsdk-maintainer/SKILL.md` do not apply.
+
+`llm/skills` distribution findings from https://github.com/roxblnfk/skills:
+
+- A Composer donor package declares a skill source with `composer.json`:
+
+```json
+{
+  "extra": {
+    "skills": { "source": "resources/skills" }
+  }
+}
+```
+
+- `composer skills:update` copies immediate skill directories from the donor source into the
+  consumer target, defaulting to `.agents/skills`.
+- Consumer `skills.json` can mirror the target to Claude Code with aliases such as
+  `.claude/skills`.
+- A direct Composer dependency is trusted by `llm/skills`, and an explicitly named package on
+  `composer skills:update bitrix24/b24phpsdk` is also treated as trusted for that run.
+- Alias creation is non-destructive; a real existing `.claude/skills` directory cannot be replaced
+  by an alias. This repository therefore needs explicit local Claude/Codex loader skills instead of
+  relying on an alias inside the SDK repository itself.
+
+---
+
+## Files to Create
+
+### 1. `resources/skills/b24phpsdk-developer/SKILL.md`
+
+Canonical distributable skill. It must include:
+
+- YAML frontmatter:
+
+```yaml
+---
+name: b24phpsdk-developer
+description: Use when writing product application code with bitrix24/b24phpsdk, integrating Bitrix24 webhooks or OAuth, choosing SDK service calls, handling SDK results, errors, pagination, batch calls, or tests outside the SDK repository
+---
+```
+
+- Scope boundaries:
+  - use for product code built on top of the SDK
+  - do not use for SDK repository issue/PR/release workflow
+  - do not use for adding SDK internals or generated REST service wrappers
+- Quick workflow:
+  1. Inspect installed SDK version and available public API.
+  2. Prefer `ServiceBuilderFactory` and public service builders over direct REST calls.
+  3. Choose webhook initialization for backend integrations with incoming webhooks, OAuth only when
+     the product owns app installation/token refresh.
+  4. Keep Bitrix24 credentials in environment/config, never inline.
+  5. Handle `BaseException` and `TransportException` at the application boundary.
+  6. Use SDK result objects and documented accessors instead of indexing raw response arrays first.
+  7. Use pagination/batch helpers deliberately; do not assume one REST call reads all records.
+  8. Test product logic with fakes around the SDK boundary and keep live Bitrix24 checks as
+     explicit integration tests.
+- Reference routing table for the files below.
+
+### 2. `resources/skills/b24phpsdk-developer/references/product-integration.md`
+
+Reference for product integration patterns:
+
+- Composer installation and version inspection.
+- `ServiceBuilderFactory::initFromWebhook($webhookUrl)` usage.
+- `ServiceBuilderFactory`/OAuth boundary guidance when available in the installed SDK version.
+- Dependency injection recommendations: construct SDK services at the infrastructure edge, pass
+  product-owned interfaces into domain code.
+- Read-only CRM contact list hello-world example:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+require __DIR__ . '/vendor/autoload.php';
+
+use Bitrix24\SDK\Services\ServiceBuilderFactory;
+
+$webhookUrl = getenv('BITRIX24_WEBHOOK');
+if ($webhookUrl === false || $webhookUrl === '') {
+    fwrite(STDERR, "BITRIX24_WEBHOOK is required\n");
+    exit(1);
+}
+
+$serviceBuilder = ServiceBuilderFactory::createServiceBuilderFromWebhook($webhookUrl);
+$contacts = $serviceBuilder
+    ->getCRMScope()
+    ->contact()
+    ->list(['ID' => 'ASC'], [], ['ID', 'NAME', 'LAST_NAME'], 0)
+    ->getContacts();
+
+echo json_encode(
+    [
+        'count' => count($contacts),
+        'items' => array_map(
+            static fn ($contact): array => [
+                'id' => $contact->ID,
+                'name' => trim(sprintf('%s %s', $contact->NAME ?? '', $contact->LAST_NAME ?? '')),
+            ],
+            $contacts,
+        ),
+    ],
+    JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT,
+) . PHP_EOL;
+```
+
+### 3. `resources/skills/b24phpsdk-developer/references/result-handling.md`
+
+Reference for SDK result handling:
+
+- Prefer typed SDK result wrappers and accessors (`getContacts()`, entity result accessors, field
+  result helpers) over raw `getCoreResponse()` traversal in product code.
+- Use raw core responses only for diagnostics, feature gaps, logging, or temporary compatibility
+  checks.
+- Explain CRM v1 list shape versus REST v3 `result.items` shape at a consumer level.
+- Explain pagination and batch trade-offs at a consumer level.
+
+### 4. `resources/skills/b24phpsdk-developer/references/error-handling-and-testing.md`
+
+Reference for error handling and tests:
+
+- Catch SDK exceptions at application boundaries.
+- Log method/scope/context without leaking webhook tokens or OAuth tokens.
+- Keep retry policy outside random call sites; retry only idempotent reads or explicitly safe writes.
+- Unit-test product code with adapters/fakes around SDK calls.
+- Keep live Bitrix24 tests opt-in and driven by `BITRIX24_WEBHOOK`.
+
+### 5. `.agents/skills/b24phpsdk-developer/SKILL.md`
+
+Codex project-skill loader for this repository. It must share the same `name` and trigger-oriented
+description as the canonical skill, then instruct the agent to read:
+
+```text
+resources/skills/b24phpsdk-developer/SKILL.md
+```
+
+The loader must not duplicate the long content; canonical content remains in `resources/skills/`.
+
+### 6. `.claude/skills/b24phpsdk-developer/SKILL.md`
+
+Claude Code project-skill loader for this repository. It must share the same `name` and
+trigger-oriented description as the canonical skill, then instruct Claude Code to read:
+
+```text
+resources/skills/b24phpsdk-developer/SKILL.md
+```
+
+The loader must coexist with `.claude/skills/b24phpsdk-maintainer/`.
+
+### 7. `.tasks/562/skill-pressure-scenarios.md`
+
+Documentation-TDD test scenarios for the skill:
+
+- Scenario A: "Create a PHP CLI script in a product app that reads Bitrix24 contacts using
+  bitrix24/b24phpsdk."
+- Scenario B: "Add error handling and logging around a Bitrix24 SDK read call without leaking
+  credentials."
+- Scenario C: "Write product tests for code that uses b24phpsdk without hitting live Bitrix24 in
+  unit tests."
+
+For each scenario, record baseline behavior before the new skill exists, expected behavior after
+the skill exists, and any rationalizations or gaps found during testing.
+
+### 8. `.tasks/562/smoke-hello-world.sh`
+
+Executable smoke-test script for the empty-project verification. It must:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${BITRIX24_WEBHOOK:?Set BITRIX24_WEBHOOK to an incoming webhook with crm scope}"
+
+SDK_REPO="${SDK_REPO:-/Users/mesilov/work/Bitrix24/b24phpsdk/.worktrees/feature-562-add-bitrix24-sdk-developer-skill}"
+WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/b24phpsdk-skill-smoke.XXXXXX")"
+if [[ "${KEEP_SMOKE_WORKDIR:-0}" == "1" ]]; then
+    printf 'Keeping smoke workdir: %s\n' "$WORKDIR"
+else
+    trap 'rm -rf "$WORKDIR"' EXIT
+fi
+
+run_php_cli() {
+    docker compose run --rm -T \
+        --user "$(id -u):$(id -g)" \
+        -e BITRIX24_WEBHOOK \
+        -v "$WORKDIR:/workspace" \
+        -v "$SDK_REPO:/sdk" \
+        -w /workspace \
+        php-cli "$@"
+}
+
+run_php_cli composer init --no-interaction --name=bitrix24/sdk-skill-smoke --type=project
+run_php_cli composer config allow-plugins.llm/skills true
+run_php_cli composer config minimum-stability dev
+run_php_cli composer config prefer-stable true
+run_php_cli composer config repositories.b24phpsdk '{"type":"path","url":"/sdk","options":{"symlink":false}}'
+
+cat > "$WORKDIR/skills.json" <<'JSON'
+{
+  "$schema": "https://raw.githubusercontent.com/roxblnfk/skills/master/resources/skills.schema.json",
+  "target": ".agents/skills",
+  "aliases": [".claude/skills"],
+  "auto-sync": true
+}
+JSON
+
+run_php_cli composer require --no-interaction --dev llm/skills
+run_php_cli composer require --no-interaction bitrix24/b24phpsdk:@dev
+run_php_cli composer skills:update bitrix24/b24phpsdk
+
+test -f "$WORKDIR/.agents/skills/b24phpsdk-developer/SKILL.md" || {
+    printf 'Missing Codex skill in %s\n' "$WORKDIR/.agents/skills" >&2
+    exit 1
+}
+run_php_cli sh -lc 'test -f .claude/skills/b24phpsdk-developer/SKILL.md' || {
+    printf 'Missing Claude Code skill via alias in %s\n' "$WORKDIR/.claude/skills" >&2
+    exit 1
+}
+
+cat > "$WORKDIR/hello-world.php" <<'PHP'
+<?php
+
+declare(strict_types=1);
+
+require __DIR__ . '/vendor/autoload.php';
+
+use Bitrix24\SDK\Services\ServiceBuilderFactory;
+
+$webhookUrl = getenv('BITRIX24_WEBHOOK');
+if ($webhookUrl === false || $webhookUrl === '') {
+    fwrite(STDERR, "BITRIX24_WEBHOOK is required\n");
+    exit(1);
+}
+
+$contacts = ServiceBuilderFactory::createServiceBuilderFromWebhook($webhookUrl)
+    ->getCRMScope()
+    ->contact()
+    ->list(['ID' => 'ASC'], [], ['ID', 'NAME', 'LAST_NAME'], 0)
+    ->getContacts();
+
+echo json_encode(['count' => count($contacts)], JSON_THROW_ON_ERROR) . PHP_EOL;
+PHP
+
+run_php_cli php hello-world.php
+```
+
+---
+
+## Files to Modify
+
+### 1. `composer.json`
+
+Add donor-side `llm/skills` metadata:
+
+```json
+"extra": {
+  "skills": {
+    "source": "resources/skills"
+  }
+}
+```
+
+Do not add `llm/skills` as an SDK runtime or dev dependency. Product consumers install the plugin
+in their own project; the SDK only declares where its distributable skills live.
+
+### 2. `CHANGELOG.md`
+
+Under `## Unreleased` -> `### Changed`, add:
+
+```markdown
+- Updated `b24phpsdk-developer` skill: added distributable SDK consumer guidance for product
+  application developers, with Claude Code and Codex project loaders plus `llm/skills` Composer
+  metadata
+  ([#562](https://github.com/bitrix24/b24phpsdk/issues/562))
+```
+
+If any `.claude/skills/**/*.md` or `.agents/skills/**/*.md` file is created or modified, this
+CHANGELOG entry is mandatory under repository rules.
+
+### 3. GitHub issue #562
+
+After this plan is written, update the issue body with a concise "Implementation plan summary"
+section that names:
+
+- canonical skill source path
+- Claude Code loader path
+- Codex loader path
+- Composer `extra.skills.source`
+- empty-project hello-world smoke test
+
+---
+
+## Deptrac Compliance
+
+No PHP SDK source classes are added or modified. Deptrac should remain unaffected because the
+change is Markdown documentation, Composer metadata, and task verification scripts.
+
+Still run `make lint-deptrac` as part of the required issue quality gate.
+
+---
+
+## Verification
+
+Run these commands from the issue worktree:
+
+```bash
+make oa-schema-build
+python3 /Users/mesilov/.codex/skills/.system/skill-creator/scripts/quick_validate.py resources/skills/b24phpsdk-developer
+make composer "validate --strict"
+make lint-cs-fixer
+make lint-rector
+make lint-phpstan
+make lint-deptrac
+make test-unit
+BITRIX24_WEBHOOK=<webhook-with-crm-scope> .tasks/562/smoke-hello-world.sh
+```
+
+Expected results:
+
+- `quick_validate.py` exits 0 for the canonical distributable skill.
+- Composer validation exits 0 after adding `extra.skills.source`.
+- All four lint targets and `make test-unit` exit 0.
+- The smoke script creates a temporary empty Composer project, installs the SDK from this checkout,
+  installs `llm/skills`, runs `composer skills:update bitrix24/b24phpsdk`, verifies both
+  `.agents/skills/b24phpsdk-developer/SKILL.md` and `.claude/skills/b24phpsdk-developer/SKILL.md`,
+  then runs `hello-world.php` and prints a JSON object with a `count` key.
+
+---
+
+## Plan Review
+
+✓ Unambiguity — file paths, distribution source, loader responsibilities, and smoke-test commands
+are explicit.
+
+✓ Non-contradiction — the distributable source is `resources/skills`, while local Claude/Codex
+loaders only point to that canonical source and do not change maintainer-skill distribution.
+
+✓ No gaps — the plan covers issue requirements, `llm/skills` distribution, Claude Code/Codex pickup,
+CHANGELOG, validation, local quality gates, and the empty-project contact-reading smoke test.

--- a/.tasks/562/skill-pressure-scenarios.md
+++ b/.tasks/562/skill-pressure-scenarios.md
@@ -1,0 +1,68 @@
+# Skill Pressure Scenarios for issue #562
+
+These scenarios drive documentation-TDD for `b24phpsdk-developer`. Baseline behavior was inspected
+before adding the new skill files: the repository only exposed `.claude/skills/b24phpsdk-maintainer`
+and had no `.agents/skills` or `resources/skills` consumer skill source.
+
+## Scenario A: Create a PHP CLI script that reads Bitrix24 contacts
+
+Prompt:
+
+```text
+Create a PHP CLI script in a product app that reads Bitrix24 contacts using bitrix24/b24phpsdk.
+```
+
+Baseline risk before the skill:
+
+- The agent may call REST directly with `curl` or an HTTP client instead of using SDK service
+  builders.
+- The agent may inline a webhook URL or omit environment-based credential handling.
+- The agent may guess the contact list signature instead of inspecting the installed SDK.
+- The agent may index raw response arrays instead of using `getContacts()`.
+
+Expected behavior after the skill:
+
+- Inspect installed `bitrix24/b24phpsdk` version and public service API.
+- Initialize with `ServiceBuilderFactory::createServiceBuilderFromWebhook($webhookUrl)`.
+- Read `BITRIX24_WEBHOOK` from environment.
+- Call `getCRMScope()->contact()->list(...)->getContacts()`.
+
+## Scenario B: Add error handling and logging around a Bitrix24 SDK read
+
+Prompt:
+
+```text
+Add error handling and logging around a Bitrix24 SDK read call without leaking credentials.
+```
+
+Baseline risk before the skill:
+
+- The agent may catch broad `Throwable` at random call sites.
+- The agent may log full request URLs, webhook tokens, OAuth tokens, or raw payloads.
+- The agent may add retries to every failure, including authorization or validation failures.
+
+Expected behavior after the skill:
+
+- Catch `TransportException` and `BaseException` at the product infrastructure boundary.
+- Log method/scope and safe operational context only.
+- Keep retry policy centralized and limited to idempotent reads or explicitly safe writes.
+
+## Scenario C: Write product tests for code that uses b24phpsdk
+
+Prompt:
+
+```text
+Write product tests for code that uses b24phpsdk without hitting live Bitrix24 in unit tests.
+```
+
+Baseline risk before the skill:
+
+- The agent may run live Bitrix24 calls from unit tests.
+- The agent may mock deep SDK internals instead of defining a product-owned boundary.
+- The agent may require `BITRIX24_WEBHOOK` for every test run.
+
+Expected behavior after the skill:
+
+- Unit-test domain/application code using fakes around product-owned interfaces.
+- Keep live Bitrix24 checks as explicit integration tests.
+- Skip integration tests cleanly when `BITRIX24_WEBHOOK` is not set.

--- a/.tasks/562/smoke-hello-world.sh
+++ b/.tasks/562/smoke-hello-world.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${BITRIX24_WEBHOOK:?Set BITRIX24_WEBHOOK to an incoming webhook with crm scope}"
+
+SDK_REPO="${SDK_REPO:-/Users/mesilov/work/Bitrix24/b24phpsdk/.worktrees/feature-562-add-bitrix24-sdk-developer-skill}"
+WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/b24phpsdk-skill-smoke.XXXXXX")"
+if [[ "${KEEP_SMOKE_WORKDIR:-0}" == "1" ]]; then
+    printf 'Keeping smoke workdir: %s\n' "$WORKDIR"
+else
+    trap 'rm -rf "$WORKDIR"' EXIT
+fi
+
+run_php_cli() {
+    docker compose run --rm -T \
+        --user "$(id -u):$(id -g)" \
+        -e BITRIX24_WEBHOOK \
+        -v "$WORKDIR:/workspace" \
+        -v "$SDK_REPO:/sdk" \
+        -w /workspace \
+        php-cli "$@"
+}
+
+run_php_cli composer init --no-interaction --name=bitrix24/sdk-skill-smoke --type=project
+run_php_cli composer config allow-plugins.llm/skills true
+run_php_cli composer config minimum-stability dev
+run_php_cli composer config prefer-stable true
+run_php_cli composer config repositories.b24phpsdk '{"type":"path","url":"/sdk","options":{"symlink":false}}'
+
+cat > "$WORKDIR/skills.json" <<'JSON'
+{
+  "$schema": "https://raw.githubusercontent.com/roxblnfk/skills/master/resources/skills.schema.json",
+  "target": ".agents/skills",
+  "aliases": [".claude/skills"],
+  "auto-sync": true
+}
+JSON
+
+run_php_cli composer require --no-interaction --dev llm/skills
+run_php_cli composer require --no-interaction bitrix24/b24phpsdk:@dev
+run_php_cli composer skills:update bitrix24/b24phpsdk
+
+test -f "$WORKDIR/.agents/skills/b24phpsdk-developer/SKILL.md" || {
+    printf 'Missing Codex skill in %s\n' "$WORKDIR/.agents/skills" >&2
+    exit 1
+}
+run_php_cli sh -lc 'test -f .claude/skills/b24phpsdk-developer/SKILL.md' || {
+    printf 'Missing Claude Code skill via alias in %s\n' "$WORKDIR/.claude/skills" >&2
+    exit 1
+}
+
+cat > "$WORKDIR/hello-world.php" <<'PHP'
+<?php
+
+declare(strict_types=1);
+
+require __DIR__ . '/vendor/autoload.php';
+
+use Bitrix24\SDK\Services\ServiceBuilderFactory;
+
+$webhookUrl = getenv('BITRIX24_WEBHOOK');
+if ($webhookUrl === false || $webhookUrl === '') {
+    fwrite(STDERR, "BITRIX24_WEBHOOK is required\n");
+    exit(1);
+}
+
+$contacts = ServiceBuilderFactory::createServiceBuilderFromWebhook($webhookUrl)
+    ->getCRMScope()
+    ->contact()
+    ->list(['ID' => 'ASC'], [], ['ID', 'NAME', 'LAST_NAME'], 0)
+    ->getContacts();
+
+echo json_encode(['count' => count($contacts)], JSON_THROW_ON_ERROR) . PHP_EOL;
+PHP
+
+run_php_cli php hello-world.php

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,9 @@
 
 ### Changed
 
+- Updated `b24phpsdk-developer` skill: added distributable SDK consumer guidance for product
+  application developers, with Claude Code and Codex project loaders plus `llm/skills` Composer
+  metadata ([#562](https://github.com/bitrix24/b24phpsdk/issues/562))
 - `bizproc.robot.add` and `bizproc.robot.update` now accept a `Url` value object (or a raw string) for the handler URL ([#493](https://github.com/bitrix24/b24phpsdk/issues/493))
 - `bizproc.robot.add` and `bizproc.robot.update` now accept a `RobotCode` value object (or a raw string) for the code ([#493](https://github.com/bitrix24/b24phpsdk/issues/493))
 - `bizproc.robot.add` and `bizproc.robot.update` now accept a `LocalizedString` value object (or a raw array) for the localized `NAME` / `DESCRIPTION` ([#493](https://github.com/bitrix24/b24phpsdk/issues/493))

--- a/composer.json
+++ b/composer.json
@@ -77,5 +77,10 @@
       "Bitrix24\\SDK\\Tools\\": "tools",
       "Bitrix24\\SDK\\Tests\\": "tests"
     }
+  },
+  "extra": {
+    "skills": {
+      "source": "resources/skills"
+    }
   }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -458,6 +458,7 @@
         </testsuite>
         <testsuite name="integration_tests_catalog_product_property_enum_annotations">
             <file>./tests/Integration/Services/Catalog/ProductPropertyEnum/Result/ProductPropertyEnumItemResultTest.php</file>
+        </testsuite>
         <testsuite name="integration_tests_catalog_product_property_feature">
             <directory>./tests/Integration/Services/Catalog/ProductPropertyFeature/</directory>
         </testsuite>

--- a/resources/skills/b24phpsdk-developer/SKILL.md
+++ b/resources/skills/b24phpsdk-developer/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: b24phpsdk-developer
+description: Use when writing product application code with bitrix24/b24phpsdk, integrating Bitrix24 webhooks or OAuth, choosing SDK service calls, handling SDK results, errors, pagination, batch calls, or tests outside the SDK repository
+---
+
+# Bitrix24 PHP SDK Developer
+
+## Scope
+
+Use this skill for product applications that consume `bitrix24/b24phpsdk`.
+
+Do not use it for SDK repository maintenance: GitHub issue triage, release work, changelog policy,
+OpenAPI coverage, generated SDK service wrappers, result-item annotation tests, or other SDK
+internals. In the SDK repository, those tasks belong to `b24phpsdk-maintainer`.
+
+## Workflow
+
+1. Inspect the installed package version and public API first: read `composer.lock`, run
+   `composer show bitrix24/b24phpsdk`, and search `vendor/bitrix24/b24phpsdk/src/Services` before
+   writing integration code.
+2. Prefer `ServiceBuilderFactory` and public service builders over direct REST calls.
+3. Use incoming webhook initialization for server-side integrations that can rely on a fixed portal
+   webhook. Use OAuth only when the product owns Bitrix24 app installation, token storage, and token
+   refresh.
+4. Keep webhook URLs, OAuth tokens, client secrets, and portal domains in environment or application
+   configuration. Never inline them in code, docs, test fixtures, or logs.
+5. Catch SDK exceptions at the application boundary. Do not scatter low-level SDK error handling
+   through domain code.
+6. Prefer SDK result objects and accessors such as `getContacts()` over raw response-array indexing.
+7. Treat list calls as paginated. Use batch helpers deliberately when reading many records.
+8. Test product logic with fakes around your own SDK boundary. Keep live Bitrix24 checks explicit,
+   opt-in, and driven by `BITRIX24_WEBHOOK`.
+
+## Reference Routing
+
+Read only the reference or references that match the task:
+
+| Task | Reference |
+| --- | --- |
+| Install the SDK, initialize webhook/OAuth access, or build a hello-world script | `references/product-integration.md` |
+| Work with result objects, raw responses, pagination, or batch reads | `references/result-handling.md` |
+| Add error handling, logging, retry policy, or tests around SDK usage | `references/error-handling-and-testing.md` |
+
+## Product Boundary Pattern
+
+Keep SDK-specific code in an infrastructure adapter. Domain and application services should depend
+on product-owned interfaces, not on SDK service classes directly. This makes unit tests cheap and
+keeps credential, pagination, and exception policy in one place.
+
+```php
+interface ContactDirectory
+{
+    /**
+     * @return list<array{id: int, name: string}>
+     */
+    public function recentContacts(int $limit): array;
+}
+```
+
+Implement the interface with the SDK in infrastructure code, then fake the interface in unit tests.
+
+## Common Mistakes
+
+- Calling REST endpoints directly before checking whether a typed SDK service already exists.
+- Indexing into `getCoreResponse()->getResponseData()->getResult()` for normal product logic.
+- Assuming `list()` returns every record in one request.
+- Logging full webhook URLs or OAuth tokens.
+- Letting domain services construct `ServiceBuilderFactory` or know about Bitrix24 credentials.
+- Running live Bitrix24 calls in unit tests.

--- a/resources/skills/b24phpsdk-developer/references/error-handling-and-testing.md
+++ b/resources/skills/b24phpsdk-developer/references/error-handling-and-testing.md
@@ -1,0 +1,79 @@
+# Error Handling and Testing
+
+## Application Boundary
+
+Catch SDK exceptions at the boundary where the product talks to Bitrix24:
+
+```php
+use Bitrix24\SDK\Core\Exceptions\BaseException;
+use Bitrix24\SDK\Core\Exceptions\TransportException;
+
+try {
+    $contacts = $contactService->list(['ID' => 'ASC'], [], ['ID', 'NAME'], 0)->getContacts();
+} catch (TransportException $exception) {
+    $logger->error('Bitrix24 transport error while reading contacts', [
+        'method' => 'crm.contact.list',
+        'exception' => $exception::class,
+    ]);
+
+    throw new RuntimeException('Bitrix24 is temporarily unavailable', 0, $exception);
+} catch (BaseException $exception) {
+    $logger->warning('Bitrix24 API error while reading contacts', [
+        'method' => 'crm.contact.list',
+        'exception' => $exception::class,
+    ]);
+
+    throw new RuntimeException('Bitrix24 rejected the contact read request', 0, $exception);
+}
+```
+
+Log method, scope, portal identifier, correlation IDs, and product record IDs when useful. Do not log
+webhook URLs, OAuth access tokens, refresh tokens, client secrets, or raw request payloads that may
+contain credentials.
+
+Do not log exception messages or traces by default. SDK exceptions can wrap transport-level details
+from lower layers; include them only after the product has explicit redaction for URLs, tokens,
+headers, and payloads.
+
+## Retry Policy
+
+Keep retries centralized in infrastructure code. Retry only:
+
+- idempotent reads;
+- writes with an explicit idempotency or reconciliation strategy;
+- transient transport failures or documented rate-limit errors.
+
+Do not retry validation failures, authorization failures, malformed requests, or unknown write
+outcomes without product-specific recovery logic.
+
+## Unit Tests
+
+Unit-test product logic against product-owned interfaces:
+
+```php
+final class FakeContactDirectory implements ContactDirectory
+{
+    public function recentContacts(int $limit): array
+    {
+        return [
+            ['id' => 1, 'name' => 'Ada Lovelace'],
+        ];
+    }
+}
+```
+
+This keeps unit tests fast and independent from Bitrix24 network access.
+
+## Integration Tests
+
+Live Bitrix24 tests should be explicit and opt-in:
+
+```php
+$webhookUrl = getenv('BITRIX24_WEBHOOK');
+if ($webhookUrl === false || $webhookUrl === '') {
+    self::markTestSkipped('BITRIX24_WEBHOOK is required for live Bitrix24 checks');
+}
+```
+
+Use live integration tests to verify credentials, scopes, SDK wiring, and the small set of workflows
+that cannot be proven with fakes.

--- a/resources/skills/b24phpsdk-developer/references/product-integration.md
+++ b/resources/skills/b24phpsdk-developer/references/product-integration.md
@@ -1,0 +1,108 @@
+# Product Integration
+
+## Install and Inspect
+
+Install the SDK in the product application:
+
+```bash
+composer require bitrix24/b24phpsdk
+composer show bitrix24/b24phpsdk
+```
+
+Before using a service, inspect the installed version:
+
+```bash
+rg -n "function contact|class Contact" vendor/bitrix24/b24phpsdk/src/Services
+```
+
+Use the API that exists in the installed package. The SDK evolves, so do not assume examples from a
+different branch match the consumer's version.
+
+## Webhook Initialization
+
+Use an incoming webhook for backend jobs, CLI tools, and simple server-side integrations scoped to
+one Bitrix24 portal:
+
+```php
+use Bitrix24\SDK\Services\ServiceBuilderFactory;
+
+$serviceBuilder = ServiceBuilderFactory::createServiceBuilderFromWebhook($webhookUrl);
+```
+
+The webhook URL must come from environment or configuration:
+
+```php
+$webhookUrl = getenv('BITRIX24_WEBHOOK');
+if ($webhookUrl === false || $webhookUrl === '') {
+    throw new RuntimeException('BITRIX24_WEBHOOK is required');
+}
+```
+
+Never commit real webhook URLs. They include credentials.
+
+## OAuth Boundary
+
+Use OAuth when the product is a Bitrix24 application that owns installation, token persistence, and
+refresh flow. Inspect `ServiceBuilderFactory` in the installed SDK version for the available OAuth
+factory methods. In current SDK versions, OAuth-oriented initialization is built around
+`ApplicationProfile`, `AuthToken`, portal endpoints, and application account objects.
+
+Keep OAuth token refresh and SDK construction at the infrastructure boundary. Domain services should
+not parse placement requests, store tokens, or construct SDK credentials.
+
+## Hello World: Read CRM Contacts
+
+```php
+<?php
+
+declare(strict_types=1);
+
+require __DIR__ . '/vendor/autoload.php';
+
+use Bitrix24\SDK\Services\ServiceBuilderFactory;
+
+$webhookUrl = getenv('BITRIX24_WEBHOOK');
+if ($webhookUrl === false || $webhookUrl === '') {
+    fwrite(STDERR, "BITRIX24_WEBHOOK is required\n");
+    exit(1);
+}
+
+$contacts = ServiceBuilderFactory::createServiceBuilderFromWebhook($webhookUrl)
+    ->getCRMScope()
+    ->contact()
+    ->list(['ID' => 'ASC'], [], ['ID', 'NAME', 'LAST_NAME'], 0)
+    ->getContacts();
+
+echo json_encode(
+    [
+        'count' => count($contacts),
+        'items' => array_map(
+            static fn ($contact): array => [
+                'id' => (int)$contact->ID,
+                'name' => trim(sprintf('%s %s', $contact->NAME ?? '', $contact->LAST_NAME ?? '')),
+            ],
+            $contacts,
+        ),
+    ],
+    JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT,
+) . PHP_EOL;
+```
+
+Run it with:
+
+```bash
+BITRIX24_WEBHOOK="https://example.bitrix24.com/rest/1/secret/" php hello-world.php
+```
+
+## Dependency Injection
+
+Construct SDK services at the edge of the application:
+
+```php
+$serviceBuilder = ServiceBuilderFactory::createServiceBuilderFromWebhook($webhookUrl);
+$contactService = $serviceBuilder->getCRMScope()->contact();
+```
+
+Wrap SDK services in product-owned adapters before passing them into business code. This gives the
+product a stable contract even when SDK service signatures or result wrappers change between SDK
+versions.

--- a/resources/skills/b24phpsdk-developer/references/result-handling.md
+++ b/resources/skills/b24phpsdk-developer/references/result-handling.md
@@ -1,0 +1,65 @@
+# Result Handling
+
+## Prefer SDK Result Accessors
+
+Use SDK result wrappers and accessors in product code:
+
+```php
+$result = $serviceBuilder
+    ->getCRMScope()
+    ->contact()
+    ->list(['ID' => 'ASC'], [], ['ID', 'NAME', 'LAST_NAME'], 0);
+
+$contacts = $result->getContacts();
+```
+
+Avoid raw response traversal for normal product logic:
+
+```php
+$raw = $result->getCoreResponse()->getResponseData()->getResult();
+```
+
+Raw core responses are acceptable for diagnostics, temporary compatibility checks, logging metadata,
+or investigation of an SDK feature gap. Keep those uses isolated and remove them once a typed SDK API
+covers the need.
+
+## Response Shapes
+
+The SDK hides most REST response envelope differences, but consumers still need to know the impact:
+
+- Legacy CRM v1 list methods such as `crm.contact.list` return a flat `result` array from REST and
+  SDK result objects expose typed item collections such as `getContacts()`.
+- REST v3 list methods often return data under `result.items`; SDK service result wrappers expose
+  the relevant item accessors for that service.
+- Single-item methods may return `result`, `result.item`, or a service-specific key. Prefer the SDK
+  result method instead of encoding these details into product code.
+
+## Pagination
+
+`list()` methods read a page, not necessarily the full dataset. The final integer argument on many
+legacy CRM list services is the start offset. Use it deliberately when reading a specific page.
+
+For full scans, prefer the service's batch helper when it exists:
+
+```php
+foreach ($serviceBuilder->getCRMScope()->contact()->batch->list(
+    ['ID' => 'ASC'],
+    [],
+    ['ID', 'NAME', 'LAST_NAME'],
+    500,
+) as $contact) {
+    // Process ContactItemResult.
+}
+```
+
+Batch reads reduce boilerplate for multi-page traversal, but they still call Bitrix24 REST under the
+hood. Keep limits bounded and design processing to resume safely after partial failure.
+
+## Batch Trade-Offs
+
+Use batch helpers for large read workloads or grouped operations that the SDK already supports. Do
+not use batch automatically for every call:
+
+- Batch requests make error handling less local because one batch can contain several operations.
+- Large writes must be idempotent or have a clear reconciliation strategy.
+- Reads should still select only fields the product needs.

--- a/src/Services/Catalog/CatalogServiceBuilder.php
+++ b/src/Services/Catalog/CatalogServiceBuilder.php
@@ -90,8 +90,5 @@ class CatalogServiceBuilder extends AbstractServiceBuilder
         }
 
         return $this->serviceCache[__METHOD__];
-    }  
-  
-  
-  
+    }
 }


### PR DESCRIPTION
| Q             | A                                                                                                                         |
|---------------|---------------------------------------------------------------------------------------------------------------------------|
| Bug fix?      | no                                                                                                                        |
| New feature?  | yes                                                                                                                       |
| Deprecations? | no                                                                                                                        |
| Issues        | Fix #562                                                                                                                  |
| License       | **MIT**                                                                                                                   |

Adds a distributable `b24phpsdk-developer` skill for product application developers using `bitrix24/b24phpsdk`.

The skill gives product-code guidance for SDK initialization, webhook/OAuth boundaries, service-builder usage, result handling, pagination/batch reads, safe exception handling, logging, and product-side testing. The canonical distributable source is `resources/skills/b24phpsdk-developer`, while `.agents/skills/b24phpsdk-developer` and `.claude/skills/b24phpsdk-developer` are repo-local loaders for Codex and Claude Code.

Distribution is enabled through Composer metadata:

```json
"extra": {
  "skills": {
    "source": "resources/skills"
  }
}
```

A smoke script verifies the empty-project flow: install `llm/skills`, install the SDK from this branch, run `composer skills:update bitrix24/b24phpsdk`, verify Codex and Claude Code skill paths, then run a PHP hello-world script that reads CRM contacts using `BITRIX24_WEBHOOK`.

## Test plan

- [x] `make oa-schema-build` — passed
- [x] `quick_validate.py resources/skills/b24phpsdk-developer` — passed
- [x] `make composer "validate --strict"` — passed
- [x] `make lint-all` — passed
- [x] `make test-unit` — passed: 1130 tests, 3138 assertions
- [x] `BITRIX24_WEBHOOK=<local webhook> .tasks/562/smoke-hello-world.sh` — passed, returned `{"count":50}`
- [x] Independent skill scenario review — passed, no blocking issues

Closes #562

Generated with Codex.