### PR TITLE
Fix lead batch item result type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,8 @@
 
 ### Fixed
 
+- Fixed `Services\CRM\Lead\Service\Batch::list()` returning `DealItemResult`
+  instead of `LeadItemResult` items ([#470](https://github.com/bitrix24/b24phpsdk/pull/470))
 - Fixed batch operations for `Services\Catalog\Product` using the wrong-case `ID` key instead of
   the lowercase `id` key expected by `catalog.product.list` and `catalog.product.delete`: added
   `Services\Catalog\Product\Batch` overriding `determineKeyId()` and `deleteEntityItems()`,

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -471,6 +471,7 @@
         <testsuite name="integration_tests_sign_mysafe_tail">
             <directory>./tests/Integration/Services/Sign/B2e/MySafeTail/Service/</directory>
             <directory>./tests/Integration/Services/Sign/B2e/MySafeTail/Result/</directory>
+        </testsuite>
         <testsuite name="integration_tests_scope_imbot">
             <directory>./tests/Integration/Services/IMBot/</directory>
         </testsuite>

--- a/src/Services/CRM/Lead/Service/Batch.php
+++ b/src/Services/CRM/Lead/Service/Batch.php
@@ -20,7 +20,7 @@ use Bitrix24\SDK\Core\Credentials\Scope;
 use Bitrix24\SDK\Core\Exceptions\BaseException;
 use Bitrix24\SDK\Core\Result\AddedItemBatchResult;
 use Bitrix24\SDK\Core\Result\DeletedItemBatchResult;
-use Bitrix24\SDK\Services\CRM\Deal\Result\DealItemResult;
+use Bitrix24\SDK\Services\CRM\Lead\Result\LeadItemResult;
 use Generator;
 use Psr\Log\LoggerInterface;
 
@@ -126,7 +126,7 @@ class Batch
      *                         } $filter
      * @param array    $select = ['ID','TITLE','TYPE_ID','CATEGORY_ID','STAGE_ID','STAGE_SEMANTIC_ID','IS_NEW','IS_RECURRING','IS_RETURN_CUSTOMER','IS_REPEATED_APPROACH','PROBABILITY','CURRENCY_ID','OPPORTUNITY','IS_MANUAL_OPPORTUNITY','TAX_VALUE','COMPANY_ID','CONTACT_ID','CONTACT_IDS','QUOTE_ID','BEGINDATE','CLOSEDATE','OPENED','CLOSED','COMMENTS','ASSIGNED_BY_ID','CREATED_BY_ID','MODIFY_BY_ID','DATE_CREATE','DATE_MODIFY','SOURCE_ID','SOURCE_DESCRIPTION','LEAD_ID','ADDITIONAL_INFO','LOCATION_ID','ORIGINATOR_ID','ORIGIN_ID','UTM_SOURCE','UTM_MEDIUM','UTM_CAMPAIGN','UTM_CONTENT','UTM_TERM']
      *
-     * @return Generator<int, DealItemResult>
+     * @return Generator<int, LeadItemResult>
      * @throws BaseException
      */
     #[ApiBatchMethodMetadata(
@@ -146,7 +146,7 @@ class Batch
             ]
         );
         foreach ($this->batch->getTraversableList('crm.lead.list', $order, $filter, $select, $limit) as $key => $value) {
-            yield $key => new DealItemResult($value);
+            yield $key => new LeadItemResult($value);
         }
     }
 

--- a/tests/Unit/Services/CRM/Lead/Service/BatchTest.php
+++ b/tests/Unit/Services/CRM/Lead/Service/BatchTest.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * This file is part of the bitrix24-php-sdk package.
+ *
+ * © Maksim Mesilov <mesilov.maxim@gmail.com>
+ *
+ * For the full copyright and license information, please view the MIT-LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Bitrix24\SDK\Tests\Unit\Services\CRM\Lead\Service;
+
+use Bitrix24\SDK\Core\Contracts\BatchOperationsInterface;
+use Bitrix24\SDK\Services\CRM\Lead\Result\LeadItemResult;
+use Bitrix24\SDK\Services\CRM\Lead\Service\Batch;
+use Generator;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\TestDox;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+#[CoversClass(Batch::class)]
+class BatchTest extends TestCase
+{
+    #[Test]
+    #[TestDox('list() yields LeadItemResult items')]
+    public function testListYieldsLeadItemResults(): void
+    {
+        $batchOperations = $this->createMock(BatchOperationsInterface::class);
+        $batchOperations->expects($this->once())
+            ->method('getTraversableList')
+            ->with('crm.lead.list', ['ID' => 'ASC'], ['ID' => 42], ['ID', 'TITLE'], 1)
+            ->willReturn($this->yieldValues([
+                ['ID' => 42, 'TITLE' => 'Test lead'],
+            ]));
+
+        $items = iterator_to_array(
+            (new Batch($batchOperations, new NullLogger()))->list(
+                ['ID' => 'ASC'],
+                ['ID' => 42],
+                ['ID', 'TITLE'],
+                1
+            )
+        );
+
+        $this->assertContainsOnlyInstancesOf(LeadItemResult::class, $items);
+    }
+
+    /**
+     * @param list<array<string, mixed>> $values
+     */
+    private function yieldValues(array $values): Generator
+    {
+        foreach ($values as $key => $value) {
+            yield $key => $value;
+        }
+    }
+}


### PR DESCRIPTION
| Q             | A                                                                                                                         |
|---------------|---------------------------------------------------------------------------------------------------------------------------|
| Bug fix?      | yes                                                                                                                       |
| New feature?  | no                                                                                                                        |
| Deprecations? | no                                                                                                                        |
| Issues        | N/A - supersedes #470; no separate issue exists                                                                           |
| License       | **MIT**                                                                                                                   |

Fixes `Services\CRM\Lead\Service\Batch::list()` so batched lead listing yields `LeadItemResult` objects instead of `DealItemResult` objects.

Supersedes #470. That PR has the correct intent, but its branch is based on an old `v3` ancestor and now contains a large amount of unrelated history and conflicts. This PR reapplies only the intended lead batch result-type fix on top of current `v3-dev`, keeping the review focused and mergeable.

The PR also fixes a malformed `phpunit.xml.dist` testsuite block that prevented PHPUnit from parsing the current `v3-dev` config.

## Test plan

- [x] `make -s oa-schema-build BITRIX24_WEBHOOK=...` - passed
- [x] `make test-file path=tests/Unit/Services/CRM/Lead/Service/BatchTest.php` - failed before the fix with `DealItemResult`, passed after the fix
- [x] `make lint-cs-fixer` - passed
- [x] `make lint-rector` - passed
- [x] `make lint-phpstan` - passed
- [x] `make lint-deptrac` - passed
- [x] `make test-unit` - passed, 1221 tests / 3336 assertions
- [x] `make lint-all` - passed
