### PR TITLE
Fix main scope code handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -442,6 +442,8 @@
 
 ### Fixed
 
+- Fixed `Bitrix24\SDK\Core\Credentials\Scope` validation for the `main` scope code
+  ([#413](https://github.com/bitrix24/b24phpsdk/issues/413))
 - Fixed batch operations for `Services\Catalog\Product` using the wrong-case `ID` key instead of
   the lowercase `id` key expected by `catalog.product.list` and `catalog.product.delete`: added
   `Services\Catalog\Product\Batch` overriding `determineKeyId()` and `deleteEntityItems()`,

--- a/tests/Unit/Core/Credentials/ScopeTest.php
+++ b/tests/Unit/Core/Credentials/ScopeTest.php
@@ -104,6 +104,18 @@ class ScopeTest extends TestCase
         $this->assertFalse($scope->contains('user'));
     }
 
+    /**
+     * @throws UnknownScopeCodeException
+     */
+    public function testMainScopeCodeIsAvailable(): void
+    {
+        $scope = new Scope(['main']);
+
+        $this->assertContains('main', Scope::getAvailableScopeCodes());
+        $this->assertEquals(['main'], $scope->getScopeCodes());
+        $this->assertTrue($scope->contains('main'));
+    }
+
     public function testContainsWithUnknownScopeCode(): void
     {
         $scope = Scope::initFromString('crm,telephony');


### PR DESCRIPTION
| Q             | A       |
|---------------|---------|
| Bug fix?      | yes     |
| New feature?  | no      |
| Deprecations? | no      |
| Issues        | Fix #413 |
| License       | **MIT** |

Adds explicit regression coverage for the `main` Bitrix24 scope code in `Scope`.

The current `dev` branch already accepts `main`; this PR keeps that behavior protected by a focused unit test and documents the v1 fix in `CHANGELOG.md`.

Validation:

- `docker compose run --rm php-cli vendor/bin/phpunit tests/Unit/Core/Credentials/ScopeTest.php --display-warnings`
- `make test-unit`
- `make lint-cs-fixer`
- `make lint-phpstan`
- `make lint-rector`
- `make lint-allowed-licenses`
