### PR TITLE
Ship SDK release 1.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 1.11.0 - 2026.08.31
+
 ### Added
 
 - Added service `Services\Catalog\ProductPropertyFeature` with support for `catalog.productPropertyFeature.*`
@@ -452,6 +454,7 @@
   instances instead of `CatalogItemResult` ([#527](https://github.com/bitrix24/b24phpsdk/issues/527))
 ### Changed
 
+- Added PHP 8.5 to supported versions in `composer.json` (`php` requirement updated to `8.2.* || 8.3.* || 8.4.* || 8.5.*`)
 - `Bitrix24\SDK\Services\Placement\Service\Placement::bind()` — `$options` parameter now accepts `PlacementOptionsInterface|array` (previously `array` only), enabling typed fluent options builders to be passed directly
 
 ## 3.0.0 - 2026.01.01
@@ -732,12 +735,6 @@ Supported in bitrix24-php-sdk methods count: 697
 Coverage percentage: 59.83% 🚀
 Supported in bitrix24-php-sdk methods with batch wrapper count: 91
 ```
-## 1.11.0 - upcoming
-
-### Changed
-
-- Added PHP 8.5 to supported versions in `composer.json` (`php` requirement updated to `8.2.* || 8.3.* || 8.4.* || 8.5.*`)
-
 ## 1.10.1 - 2026.02.25
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ If You work on Windows:
 - please use [WSL - Windows Subsystem for Linux](https://learn.microsoft.com/en-us/windows/wsl/) 
 - if your filesystem is NTFS, You can disable flag `git config --global core.protectNTFS false` for checkout folders started with dot.
 
-Or add `"bitrix24/b24phpsdk": "1.10.*"` to `composer.json` of your application.
+Or add `"bitrix24/b24phpsdk": "1.11.*"` to `composer.json` of your application.
 
 ## B24PhpSdk ✨FEATURES✨
 

--- a/src/Core/ApiClient.php
+++ b/src/Core/ApiClient.php
@@ -36,7 +36,7 @@ class ApiClient implements ApiClientInterface
     /**
      * @const string
      */
-    protected const SDK_VERSION = '1.10.0';
+    protected const SDK_VERSION = '1.11.0';
 
     protected const SDK_USER_AGENT = 'b24-php-sdk-vendor';
 


### PR DESCRIPTION
| Q             | A      |
|---------------|--------|
| Bug fix?      | no     |
| New feature?  | no     |
| Deprecations? | no     |
| Issues        | Fix #597 |
| License       | MIT    |

## Summary

- Bump SDK header version to 1.11.0.
- Update README Composer constraint to 1.11.*.
- Mark the changelog release section as 1.11.0 and merge the existing upcoming note into it.

## Validation

- `git diff --check`
- `docker compose run --rm php-cli composer validate --strict`
- `docker compose run --rm php-cli vendor/bin/phpunit tests/Unit/Core/ApiClientTest.php --display-warnings`